### PR TITLE
Fix NRT errors and enable TreatWarningsAsErrors

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,6 +16,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/samples/Foundatio.RabbitMQ.Publish/OrderEvent.cs
+++ b/samples/Foundatio.RabbitMQ.Publish/OrderEvent.cs
@@ -7,10 +7,10 @@ public record OrderEvent
     public string OrderId { get; init; } = Guid.NewGuid().ToString("N");
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
     public int SequenceNumber { get; init; }
-    public string CustomerId { get; init; }
+    public string CustomerId { get; init; } = null!;
     public decimal Amount { get; init; }
-    public string Status { get; init; }
-    public string Notes { get; init; }
+    public string Status { get; init; } = null!;
+    public string? Notes { get; init; }
 
     public static OrderEvent Create(int sequenceNumber, int targetSizeBytes = 0)
     {

--- a/samples/Foundatio.RabbitMQ.Publish/OrderEvent.cs
+++ b/samples/Foundatio.RabbitMQ.Publish/OrderEvent.cs
@@ -7,9 +7,9 @@ public record OrderEvent
     public string OrderId { get; init; } = Guid.NewGuid().ToString("N");
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
     public int SequenceNumber { get; init; }
-    public string CustomerId { get; init; } = null!;
+    public required string CustomerId { get; init; }
     public decimal Amount { get; init; }
-    public string Status { get; init; } = null!;
+    public required string Status { get; init; }
     public string? Notes { get; init; }
 
     public static OrderEvent Create(int sequenceNumber, int targetSizeBytes = 0)

--- a/samples/Foundatio.RabbitMQ.Publish/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Publish/Program.cs
@@ -100,12 +100,12 @@ RootCommand rootCommand = new("RabbitMQ Order Publisher Sample")
 
 rootCommand.SetAction(parseResult =>
 {
-    string connectionString = parseResult.GetValue(connectionStringOption);
-    string hosts = parseResult.GetValue(hostsOption);
-    string topic = parseResult.GetValue(topicOption);
+    string? connectionString = parseResult.GetValue(connectionStringOption);
+    string? hosts = parseResult.GetValue(hostsOption);
+    string? topic = parseResult.GetValue(topicOption);
     bool durable = parseResult.GetValue(durableOption);
     bool delayed = parseResult.GetValue(delayedOption);
-    string acknowledgmentStrategy = parseResult.GetValue(acknowledgmentStrategyOption);
+    string? acknowledgmentStrategy = parseResult.GetValue(acknowledgmentStrategyOption);
     bool publisherConfirms = parseResult.GetValue(publisherConfirmsOption);
     int messageSize = parseResult.GetValue(messageSizeOption);
     ushort prefetchCount = parseResult.GetValue(prefetchCountOption);
@@ -115,7 +115,7 @@ rootCommand.SetAction(parseResult =>
     LogLevel logLevel = parseResult.GetValue(logLevelOption);
 
     return RunPublisher(
-        connectionString, hosts, topic, durable, delayed, acknowledgmentStrategy, publisherConfirms,
+        connectionString!, hosts ?? "", topic!, durable, delayed, acknowledgmentStrategy!, publisherConfirms,
         messageSize, prefetchCount, deliveryLimit, delaySeconds, interval, logLevel);
 });
 
@@ -235,7 +235,7 @@ static async Task RunPublisher(
         int orderCount = 0;
         do
         {
-            string input = Console.ReadLine();
+            string? input = Console.ReadLine();
             if (String.IsNullOrEmpty(input))
                 break;
 

--- a/samples/Foundatio.RabbitMQ.Publish/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Publish/Program.cs
@@ -136,7 +136,7 @@ static async Task RunPublisher(
     int interval,
     LogLevel logLevel)
 {
-    ArgumentException.ThrowIfNullOrEmpty(connectionString);
+    ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
     ArgumentException.ThrowIfNullOrEmpty(topic);
 
     using var loggerFactory = LoggerFactory.Create(builder =>

--- a/samples/Foundatio.RabbitMQ.Publish/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Publish/Program.cs
@@ -115,19 +115,19 @@ rootCommand.SetAction(parseResult =>
     LogLevel logLevel = parseResult.GetValue(logLevelOption);
 
     return RunPublisher(
-        connectionString!, hosts ?? "", topic!, durable, delayed, acknowledgmentStrategy!, publisherConfirms,
+        connectionString, hosts, topic, durable, delayed, acknowledgmentStrategy, publisherConfirms,
         messageSize, prefetchCount, deliveryLimit, delaySeconds, interval, logLevel);
 });
 
 return await rootCommand.Parse(args).InvokeAsync();
 
 static async Task RunPublisher(
-    string connectionString,
-    string hosts,
-    string topic,
+    string? connectionString,
+    string? hosts,
+    string? topic,
     bool durable,
     bool delayed,
-    string acknowledgmentStrategy,
+    string? acknowledgmentStrategy,
     bool publisherConfirms,
     int messageSize,
     ushort prefetchCount,
@@ -136,6 +136,9 @@ static async Task RunPublisher(
     int interval,
     LogLevel logLevel)
 {
+    ArgumentException.ThrowIfNullOrEmpty(connectionString);
+    ArgumentException.ThrowIfNullOrEmpty(topic);
+
     using var loggerFactory = LoggerFactory.Create(builder =>
     {
         builder.AddConsole().SetMinimumLevel(logLevel);

--- a/samples/Foundatio.RabbitMQ.Publish/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Publish/Program.cs
@@ -137,7 +137,7 @@ static async Task RunPublisher(
     LogLevel logLevel)
 {
     ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
-    ArgumentException.ThrowIfNullOrEmpty(topic);
+    ArgumentException.ThrowIfNullOrWhiteSpace(topic);
 
     using var loggerFactory = LoggerFactory.Create(builder =>
     {

--- a/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
@@ -121,8 +121,8 @@ static async Task RunSubscriberAsync(
     LogLevel logLevel)
 {
     ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
-    ArgumentException.ThrowIfNullOrEmpty(topic);
-    ArgumentException.ThrowIfNullOrEmpty(groupId);
+    ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+    ArgumentException.ThrowIfNullOrWhiteSpace(groupId);
 
     using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
     {

--- a/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
@@ -120,7 +120,7 @@ static async Task RunSubscriberAsync(
     string? groupId,
     LogLevel logLevel)
 {
-    ArgumentException.ThrowIfNullOrEmpty(connectionString);
+    ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
     ArgumentException.ThrowIfNullOrEmpty(topic);
     ArgumentException.ThrowIfNullOrEmpty(groupId);
 

--- a/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
@@ -88,21 +88,21 @@ RootCommand rootCommand = new("RabbitMQ Order Subscriber Sample")
 
 rootCommand.SetAction(parseResult =>
 {
-    string connectionString = parseResult.GetValue(connectionStringOption);
-    string hosts = parseResult.GetValue(hostsOption);
-    string topic = parseResult.GetValue(topicOption);
+    string? connectionString = parseResult.GetValue(connectionStringOption);
+    string? hosts = parseResult.GetValue(hostsOption);
+    string? topic = parseResult.GetValue(topicOption);
     bool durable = parseResult.GetValue(durableOption);
     bool delayed = parseResult.GetValue(delayedOption);
-    string acknowledgmentStrategy = parseResult.GetValue(acknowledgmentStrategyOption);
+    string? acknowledgmentStrategy = parseResult.GetValue(acknowledgmentStrategyOption);
     ushort prefetchCount = parseResult.GetValue(prefetchCountOption);
     long deliveryLimit = parseResult.GetValue(deliveryLimitOption);
     int subscriberCount = parseResult.GetValue(subscriberCountOption);
-    string groupId = parseResult.GetValue(groupIdOption);
+    string? groupId = parseResult.GetValue(groupIdOption);
     LogLevel logLevel = parseResult.GetValue(logLevelOption);
 
     return RunSubscriberAsync(
-        connectionString, hosts, topic, durable, delayed, acknowledgmentStrategy,
-        prefetchCount, deliveryLimit, subscriberCount, groupId, logLevel);
+        connectionString!, hosts ?? "", topic!, durable, delayed, acknowledgmentStrategy!,
+        prefetchCount, deliveryLimit, subscriberCount, groupId!, logLevel);
 });
 
 return await rootCommand.Parse(args).InvokeAsync();

--- a/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
+++ b/samples/Foundatio.RabbitMQ.Subscribe/Program.cs
@@ -101,25 +101,29 @@ rootCommand.SetAction(parseResult =>
     LogLevel logLevel = parseResult.GetValue(logLevelOption);
 
     return RunSubscriberAsync(
-        connectionString!, hosts ?? "", topic!, durable, delayed, acknowledgmentStrategy!,
-        prefetchCount, deliveryLimit, subscriberCount, groupId!, logLevel);
+        connectionString, hosts, topic, durable, delayed, acknowledgmentStrategy,
+        prefetchCount, deliveryLimit, subscriberCount, groupId, logLevel);
 });
 
 return await rootCommand.Parse(args).InvokeAsync();
 
 static async Task RunSubscriberAsync(
-    string connectionString,
-    string hosts,
-    string topic,
+    string? connectionString,
+    string? hosts,
+    string? topic,
     bool durable,
     bool delayed,
-    string acknowledgmentStrategy,
+    string? acknowledgmentStrategy,
     ushort prefetchCount,
     long deliveryLimit,
     int subscriberCount,
-    string groupId,
+    string? groupId,
     LogLevel logLevel)
 {
+    ArgumentException.ThrowIfNullOrEmpty(connectionString);
+    ArgumentException.ThrowIfNullOrEmpty(topic);
+    ArgumentException.ThrowIfNullOrEmpty(groupId);
+
     using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
     {
         builder.AddConsole().SetMinimumLevel(logLevel);

--- a/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
+++ b/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
+++ b/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
+++ b/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -35,8 +35,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     public RabbitMQMessageBus(RabbitMQMessageBusOptions options) : base(options)
     {
-        if (String.IsNullOrEmpty(options.ConnectionString))
-            throw new ArgumentException("ConnectionString is required.");
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString, nameof(options.ConnectionString));
 
         if (!Uri.TryCreate(options.ConnectionString, UriKind.Absolute, out var primaryUri))
             throw new ArgumentException($"ConnectionString is not a valid URI: {options.ConnectionString}");
@@ -682,8 +681,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
         _isDisposed = true;
 
-        if (_factory is not null)
-            _factory.AutomaticRecoveryEnabled = false;
+        _factory.AutomaticRecoveryEnabled = false;
 
         ClosePublisherConnection();
         CloseSubscriberConnection();
@@ -699,8 +697,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
         _isDisposed = true;
 
-        if (_factory is not null)
-            _factory.AutomaticRecoveryEnabled = false;
+        _factory.AutomaticRecoveryEnabled = false;
 
         await ClosePublisherConnectionAsync().AnyContext();
         await CloseSubscriberConnectionAsync().AnyContext();

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -379,9 +379,6 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private async Task PublishMessageAsync(string exchange, string routingKey, byte[] body, BasicProperties properties, CancellationToken cancellationToken)
     {
-        if (_publisherChannel is null)
-            throw new MessageBusException("Publisher channel must be initialized before publishing messages.");
-
         using (await _lock.LockAsync(cancellationToken).AnyContext())
         {
             var channel = _publisherChannel;

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -236,7 +236,10 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task HandleDeliveryLimitsAsync(BasicDeliverEventArgs envelope)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-            throw new MessageBusException("Subscriber channel is not available. Cannot handle delivery limits.");
+        {
+            _logger.LogWarning("Subscriber channel is not available; skipping delivery limit handling for message ({MessageId})", envelope.BasicProperties.MessageId);
+            return;
+        }
 
         // Rule 1: If the limit is negative, reject regardless of queue type
         if (_options.DeliveryLimit < 0)

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -194,8 +194,11 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private async Task OnMessageAsync(object sender, BasicDeliverEventArgs envelope)
     {
+        if (_subscriberChannel is not { } subscriberChannel)
+            throw new InvalidOperationException("Subscriber channel is not initialized.");
+
         using var _ = _logger.BeginScope(s => s
-            .Property("MessageId", envelope.BasicProperties.MessageId ?? "(none)")
+            .Property("MessageId", envelope.BasicProperties.MessageId)
             .Property("DeliveryTag", envelope.DeliveryTag));
 
         _logger.LogTrace("OnMessageAsync({MessageId})", envelope.BasicProperties.MessageId);
@@ -203,8 +206,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         if (_subscribers.IsEmpty)
         {
             _logger.LogTrace("No subscribers ({MessageId})", envelope.BasicProperties.MessageId);
-            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic && _subscriberChannel is { } rejectChannel)
-                await rejectChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
+                await subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
 
             return;
         }
@@ -214,8 +217,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             var message = ConvertToMessage(envelope);
             await SendMessageToSubscribersAsync(message).AnyContext();
 
-            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic && _subscriberChannel is { } ackChannel)
-                await ackChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
+                await subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
         }
         catch (MessageBusException)
         {
@@ -232,16 +235,15 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private async Task HandleDeliveryLimitsAsync(BasicDeliverEventArgs envelope)
     {
-        var channel = _subscriberChannel;
-        if (channel is null)
-            return;
+        if (_subscriberChannel is not { } subscriberChannel)
+            throw new InvalidOperationException("Subscriber channel is not initialized.");
 
         // Rule 1: If the limit is negative, reject regardless of queue type
         if (_options.DeliveryLimit < 0)
         {
             _logger.LogDebug("Message ({MessageId}) rejected due to negative delivery limit ({DeliveryLimit})",
                 envelope.BasicProperties.MessageId, _options.DeliveryLimit);
-            await channel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+            await subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
             return;
         }
 
@@ -262,14 +264,14 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                     _logger.LogWarning(
                         "Quorum queue message ({MessageId}) delivery count ({DeliveryCount}) is over configured limit ({DeliveryLimit})",
                         envelope.BasicProperties.MessageId, retryCount, _options.DeliveryLimit);
-                    await channel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+                    await subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
                 }
                 else
                 {
                     _logger.LogDebug(
                         "Quorum queue message ({MessageId}) has exceeded delivery limit ({DeliveryLimit}): Rejecting to let broker handle",
                         envelope.BasicProperties.MessageId, _options.DeliveryLimit);
-                    await channel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+                    await subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
                 }
             }
             else
@@ -277,7 +279,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 _logger.LogDebug(
                     "Classic queue message ({MessageId}) has reached the delivery limit of {DeliveryLimit}: Acknowledging message",
                     envelope.BasicProperties.MessageId, _options.DeliveryLimit);
-                await channel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+                await subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
             }
 
             return;
@@ -289,7 +291,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             _logger.LogDebug(
                 "Quorum queue message ({MessageId}) under delivery limit: Rejecting for broker-managed redelivery",
                 envelope.BasicProperties.MessageId);
-            await channel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+            await subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
         }
         else
         {
@@ -299,6 +301,9 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private async Task RepublishMessageWithIncrementedDeliveryCountAsync(BasicDeliverEventArgs envelope, long currentRetryCount)
     {
+        if (_subscriberChannel is not { } subscriberChannel)
+            throw new InvalidOperationException("Subscriber channel is not initialized.");
+
         string originalMessageId = GetOriginalMessageIdFromHeader(envelope);
         var properties = new BasicProperties(envelope.BasicProperties)
         {
@@ -320,9 +325,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         {
             await EnsureTopicCreatedAsync(envelope.CancellationToken).AnyContext();
             await PublishMessageAsync(envelope.Exchange, envelope.RoutingKey, envelope.Body.ToArray(), properties, envelope.CancellationToken).AnyContext();
-
-            if (_subscriberChannel is { } ackChannel)
-                await ackChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+            await subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
 
             _logger.LogDebug("Republished classic queue message ({MessageId}) (OriginalMessageId={OriginalMessageId}) with delivery count {DeliveryCount}",
                 envelope.BasicProperties.MessageId, originalMessageId, currentRetryCount + 1);
@@ -330,9 +333,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to republish message ({MessageId}), acknowledging to prevent infinite retry", envelope.BasicProperties.MessageId);
-
-            if (_subscriberChannel is { } fallbackChannel)
-                await fallbackChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+            await subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
         }
     }
 
@@ -360,16 +361,19 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             {
                 string str => str,
                 byte[] bytes => Encoding.UTF8.GetString(bytes),
-                null => envelope.BasicProperties.MessageId ?? string.Empty,
-                _ => xOriginalMessageId.ToString() ?? envelope.BasicProperties.MessageId ?? string.Empty
+                null => envelope.BasicProperties.MessageId ?? String.Empty,
+                _ => xOriginalMessageId.ToString() ?? envelope.BasicProperties.MessageId ?? String.Empty
             };
         }
 
-        return envelope.BasicProperties.MessageId ?? string.Empty;
+        return envelope.BasicProperties.MessageId ?? String.Empty;
     }
 
     private async Task PublishMessageAsync(string exchange, string routingKey, byte[] body, BasicProperties properties, CancellationToken cancellationToken)
     {
+        if (_publisherChannel is null)
+            throw new InvalidOperationException("Publisher channel must be initialized before publishing messages.");
+
         using (await _lock.LockAsync(cancellationToken).AnyContext())
         {
             await _resiliencePolicy.ExecuteAsync(async _ =>
@@ -379,34 +383,28 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 if (_isPublisherBlocked)
                     throw new MessageBusException($"Cannot publish: publisher connection is blocked by broker ({_publisherBlockedReason ?? "resource alarm"})");
 
-                await _publisherChannel!.BasicPublishAsync(exchange, routingKey, mandatory: false, properties, body, cancellationToken: cancellationToken);
+                await _publisherChannel.BasicPublishAsync(exchange, routingKey, mandatory: false, properties, body, cancellationToken: cancellationToken);
             }, cancellationToken).AnyContext();
         }
     }
 
     protected virtual IMessage ConvertToMessage(BasicDeliverEventArgs envelope)
     {
-        var messageType = envelope.BasicProperties.Type;
-        if (String.IsNullOrEmpty(messageType))
-            _logger.LogTrace("Received message without a Type header ({MessageId})", envelope.BasicProperties.MessageId);
-
         var message = new Message(envelope.Body.ToArray(), DeserializeMessageBody)
         {
-            Type = messageType ?? string.Empty,
+            Type = envelope.BasicProperties.Type,
+            ClrType = GetMappedMessageType(envelope.BasicProperties.Type),
             CorrelationId = envelope.BasicProperties.CorrelationId,
             UniqueId = envelope.BasicProperties.MessageId
         };
-
-        if (messageType is not null)
-            message.ClrType = GetMappedMessageType(messageType);
 
         if (envelope.BasicProperties.Headers is not null)
             foreach (var header in envelope.BasicProperties.Headers)
             {
                 if (header.Value is byte[] byteData)
                     message.Properties[header.Key] = Encoding.UTF8.GetString(byteData);
-                else if (header.Value?.ToString() is { } stringValue)
-                    message.Properties[header.Key] = stringValue;
+                else
+                    message.Properties[header.Key] = header.Value?.ToString() ?? String.Empty;
             }
 
         return message;
@@ -827,57 +825,75 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private void RegisterPublisherConnectionEventHandlers()
     {
-        _publisherConnection!.CallbackExceptionAsync += OnPublisherConnectionOnCallbackExceptionAsync;
-        _publisherConnection!.ConnectionBlockedAsync += OnPublisherConnectionOnConnectionBlockedAsync;
-        _publisherConnection!.ConnectionRecoveryErrorAsync += OnPublisherConnectionOnConnectionRecoveryErrorAsync;
-        _publisherConnection!.ConnectionShutdownAsync += OnPublisherConnectionOnConnectionShutdownAsync;
-        _publisherConnection!.ConnectionUnblockedAsync += OnPublisherConnectionOnConnectionUnblockedAsync;
-        _publisherConnection!.RecoveringConsumerAsync += OnPublisherConnectionOnRecoveringConsumerAsync;
-        _publisherConnection!.RecoverySucceededAsync += OnPublisherConnectionOnRecoverySucceededAsync;
+        if (_publisherConnection is null)
+            throw new InvalidOperationException("Publisher connection must be initialized before registering event handlers.");
+
+        _publisherConnection.CallbackExceptionAsync += OnPublisherConnectionOnCallbackExceptionAsync;
+        _publisherConnection.ConnectionBlockedAsync += OnPublisherConnectionOnConnectionBlockedAsync;
+        _publisherConnection.ConnectionRecoveryErrorAsync += OnPublisherConnectionOnConnectionRecoveryErrorAsync;
+        _publisherConnection.ConnectionShutdownAsync += OnPublisherConnectionOnConnectionShutdownAsync;
+        _publisherConnection.ConnectionUnblockedAsync += OnPublisherConnectionOnConnectionUnblockedAsync;
+        _publisherConnection.RecoveringConsumerAsync += OnPublisherConnectionOnRecoveringConsumerAsync;
+        _publisherConnection.RecoverySucceededAsync += OnPublisherConnectionOnRecoverySucceededAsync;
     }
 
     private void UnregisterPublisherConnectionEventHandlers()
     {
-        _publisherConnection!.CallbackExceptionAsync -= OnPublisherConnectionOnCallbackExceptionAsync;
-        _publisherConnection!.ConnectionBlockedAsync -= OnPublisherConnectionOnConnectionBlockedAsync;
-        _publisherConnection!.ConnectionRecoveryErrorAsync -= OnPublisherConnectionOnConnectionRecoveryErrorAsync;
-        _publisherConnection!.ConnectionShutdownAsync -= OnPublisherConnectionOnConnectionShutdownAsync;
-        _publisherConnection!.ConnectionUnblockedAsync -= OnPublisherConnectionOnConnectionUnblockedAsync;
-        _publisherConnection!.RecoveringConsumerAsync -= OnPublisherConnectionOnRecoveringConsumerAsync;
-        _publisherConnection!.RecoverySucceededAsync -= OnPublisherConnectionOnRecoverySucceededAsync;
+        if (_publisherConnection is null)
+            throw new InvalidOperationException("Publisher connection must be initialized before unregistering event handlers.");
+
+        _publisherConnection.CallbackExceptionAsync -= OnPublisherConnectionOnCallbackExceptionAsync;
+        _publisherConnection.ConnectionBlockedAsync -= OnPublisherConnectionOnConnectionBlockedAsync;
+        _publisherConnection.ConnectionRecoveryErrorAsync -= OnPublisherConnectionOnConnectionRecoveryErrorAsync;
+        _publisherConnection.ConnectionShutdownAsync -= OnPublisherConnectionOnConnectionShutdownAsync;
+        _publisherConnection.ConnectionUnblockedAsync -= OnPublisherConnectionOnConnectionUnblockedAsync;
+        _publisherConnection.RecoveringConsumerAsync -= OnPublisherConnectionOnRecoveringConsumerAsync;
+        _publisherConnection.RecoverySucceededAsync -= OnPublisherConnectionOnRecoverySucceededAsync;
     }
 
     private void RegisterSubscriberConnectionEventHandlers()
     {
-        _subscriberConnection!.CallbackExceptionAsync += OnSubscriberConnectionOnCallbackExceptionAsync;
-        _subscriberConnection!.ConnectionBlockedAsync += OnSubscriberConnectionOnConnectionBlockedAsync;
-        _subscriberConnection!.ConnectionRecoveryErrorAsync += OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
-        _subscriberConnection!.ConnectionShutdownAsync += OnSubscriberConnectionOnConnectionShutdownAsync;
-        _subscriberConnection!.ConnectionUnblockedAsync += OnSubscriberConnectionOnConnectionUnblockedAsync;
-        _subscriberConnection!.RecoveringConsumerAsync += OnSubscriberConnectionOnRecoveringConsumerAsync;
-        _subscriberConnection!.RecoverySucceededAsync += OnSubscriberConnectionOnRecoverySucceededAsync;
+        if (_subscriberConnection is null)
+            throw new InvalidOperationException("Subscriber connection must be initialized before registering event handlers.");
+
+        _subscriberConnection.CallbackExceptionAsync += OnSubscriberConnectionOnCallbackExceptionAsync;
+        _subscriberConnection.ConnectionBlockedAsync += OnSubscriberConnectionOnConnectionBlockedAsync;
+        _subscriberConnection.ConnectionRecoveryErrorAsync += OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
+        _subscriberConnection.ConnectionShutdownAsync += OnSubscriberConnectionOnConnectionShutdownAsync;
+        _subscriberConnection.ConnectionUnblockedAsync += OnSubscriberConnectionOnConnectionUnblockedAsync;
+        _subscriberConnection.RecoveringConsumerAsync += OnSubscriberConnectionOnRecoveringConsumerAsync;
+        _subscriberConnection.RecoverySucceededAsync += OnSubscriberConnectionOnRecoverySucceededAsync;
     }
 
     private void UnregisterSubscriberConnectionEventHandlers()
     {
-        _subscriberConnection!.CallbackExceptionAsync -= OnSubscriberConnectionOnCallbackExceptionAsync;
-        _subscriberConnection!.ConnectionBlockedAsync -= OnSubscriberConnectionOnConnectionBlockedAsync;
-        _subscriberConnection!.ConnectionRecoveryErrorAsync -= OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
-        _subscriberConnection!.ConnectionShutdownAsync -= OnSubscriberConnectionOnConnectionShutdownAsync;
-        _subscriberConnection!.ConnectionUnblockedAsync -= OnSubscriberConnectionOnConnectionUnblockedAsync;
-        _subscriberConnection!.RecoveringConsumerAsync -= OnSubscriberConnectionOnRecoveringConsumerAsync;
-        _subscriberConnection!.RecoverySucceededAsync -= OnSubscriberConnectionOnRecoverySucceededAsync;
+        if (_subscriberConnection is null)
+            throw new InvalidOperationException("Subscriber connection must be initialized before unregistering event handlers.");
+
+        _subscriberConnection.CallbackExceptionAsync -= OnSubscriberConnectionOnCallbackExceptionAsync;
+        _subscriberConnection.ConnectionBlockedAsync -= OnSubscriberConnectionOnConnectionBlockedAsync;
+        _subscriberConnection.ConnectionRecoveryErrorAsync -= OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
+        _subscriberConnection.ConnectionShutdownAsync -= OnSubscriberConnectionOnConnectionShutdownAsync;
+        _subscriberConnection.ConnectionUnblockedAsync -= OnSubscriberConnectionOnConnectionUnblockedAsync;
+        _subscriberConnection.RecoveringConsumerAsync -= OnSubscriberConnectionOnRecoveringConsumerAsync;
+        _subscriberConnection.RecoverySucceededAsync -= OnSubscriberConnectionOnRecoverySucceededAsync;
     }
 
     private void RegisterConsumerEventHandlers()
     {
-        _consumer!.ReceivedAsync += OnMessageAsync;
-        _consumer!.ShutdownAsync += OnConsumerShutdownAsync;
+        if (_consumer is null)
+            throw new InvalidOperationException("Consumer must be initialized before registering event handlers.");
+
+        _consumer.ReceivedAsync += OnMessageAsync;
+        _consumer.ShutdownAsync += OnConsumerShutdownAsync;
     }
 
     private void UnregisterConsumerEventHandlers()
     {
-        _consumer!.ReceivedAsync -= OnMessageAsync;
-        _consumer!.ShutdownAsync -= OnConsumerShutdownAsync;
+        if (_consumer is null)
+            throw new InvalidOperationException("Consumer must be initialized before unregistering event handlers.");
+
+        _consumer.ReceivedAsync -= OnMessageAsync;
+        _consumer.ShutdownAsync -= OnConsumerShutdownAsync;
     }
 }

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -22,16 +22,16 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private readonly AsyncLock _lock = new();
     private readonly ConnectionFactory _factory;
     private readonly List<AmqpTcpEndpoint> _endpoints;
-    private IConnection _publisherConnection;
-    private IConnection _subscriberConnection;
-    private IChannel _publisherChannel;
-    private IChannel _subscriberChannel;
-    private AsyncEventingBasicConsumer _consumer;
+    private IConnection? _publisherConnection;
+    private IConnection? _subscriberConnection;
+    private IChannel? _publisherChannel;
+    private IChannel? _subscriberChannel;
+    private AsyncEventingBasicConsumer? _consumer;
     private bool? _delayedExchangePluginEnabled;
     private readonly bool _isQuorumQueue;
     private bool _isDisposed;
     private volatile bool _isPublisherBlocked;
-    private volatile string _publisherBlockedReason;
+    private volatile string? _publisherBlockedReason;
 
     public RabbitMQMessageBus(RabbitMQMessageBusOptions options) : base(options)
     {
@@ -45,7 +45,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             !primaryUri.Scheme.Equals("amqps", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException($"ConnectionString must use amqp:// or amqps:// scheme: {options.ConnectionString}");
 
-        _isQuorumQueue = options.Arguments is not null && options.Arguments.TryGetValue("x-queue-type", out object queueType) && queueType is string type && String.Equals(type, "quorum", StringComparison.OrdinalIgnoreCase);
+        _isQuorumQueue = options.Arguments is not null && options.Arguments.TryGetValue("x-queue-type", out object? queueType) && queueType is string type && String.Equals(type, "quorum", StringComparison.OrdinalIgnoreCase);
 
         // Parse the connection string for credentials and vhost
         bool useSsl = primaryUri.Scheme.Equals("amqps", StringComparison.OrdinalIgnoreCase);
@@ -195,7 +195,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task OnMessageAsync(object sender, BasicDeliverEventArgs envelope)
     {
         using var _ = _logger.BeginScope(s => s
-            .Property("MessageId", envelope.BasicProperties.MessageId)
+            .Property("MessageId", envelope.BasicProperties.MessageId ?? "(none)")
             .Property("DeliveryTag", envelope.DeliveryTag));
 
         _logger.LogTrace("OnMessageAsync({MessageId})", envelope.BasicProperties.MessageId);
@@ -203,8 +203,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         if (_subscribers.IsEmpty)
         {
             _logger.LogTrace("No subscribers ({MessageId})", envelope.BasicProperties.MessageId);
-            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
-                await _subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic && _subscriberChannel is { } rejectChannel)
+                await rejectChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
 
             return;
         }
@@ -214,12 +214,11 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             var message = ConvertToMessage(envelope);
             await SendMessageToSubscribersAsync(message).AnyContext();
 
-            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
-                await _subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic && _subscriberChannel is { } ackChannel)
+                await ackChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
         }
         catch (MessageBusException)
         {
-            // SendMessageToSubscribersAsync already logged the error
             if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
                 await HandleDeliveryLimitsAsync(envelope).AnyContext();
         }
@@ -233,12 +232,16 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private async Task HandleDeliveryLimitsAsync(BasicDeliverEventArgs envelope)
     {
+        var channel = _subscriberChannel;
+        if (channel is null)
+            return;
+
         // Rule 1: If the limit is negative, reject regardless of queue type
         if (_options.DeliveryLimit < 0)
         {
             _logger.LogDebug("Message ({MessageId}) rejected due to negative delivery limit ({DeliveryLimit})",
                 envelope.BasicProperties.MessageId, _options.DeliveryLimit);
-            await _subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+            await channel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
             return;
         }
 
@@ -259,14 +262,14 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                     _logger.LogWarning(
                         "Quorum queue message ({MessageId}) delivery count ({DeliveryCount}) is over configured limit ({DeliveryLimit})",
                         envelope.BasicProperties.MessageId, retryCount, _options.DeliveryLimit);
-                    await _subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+                    await channel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
                 }
                 else
                 {
                     _logger.LogDebug(
                         "Quorum queue message ({MessageId}) has exceeded delivery limit ({DeliveryLimit}): Rejecting to let broker handle",
                         envelope.BasicProperties.MessageId, _options.DeliveryLimit);
-                    await _subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+                    await channel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
                 }
             }
             else
@@ -274,7 +277,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 _logger.LogDebug(
                     "Classic queue message ({MessageId}) has reached the delivery limit of {DeliveryLimit}: Acknowledging message",
                     envelope.BasicProperties.MessageId, _options.DeliveryLimit);
-                await _subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+                await channel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
             }
 
             return;
@@ -286,7 +289,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             _logger.LogDebug(
                 "Quorum queue message ({MessageId}) under delivery limit: Rejecting for broker-managed redelivery",
                 envelope.BasicProperties.MessageId);
-            await _subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
+            await channel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
         }
         else
         {
@@ -302,7 +305,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             MessageId = Guid.NewGuid().ToString("N")
         };
 
-        var headers = new Dictionary<string, object>(envelope.BasicProperties.Headers ?? new Dictionary<string, object>())
+        var headers = new Dictionary<string, object?>(envelope.BasicProperties.Headers ?? new Dictionary<string, object?>())
         {
             [XDeliveryCountHeader] = currentRetryCount + 1,
             [XOriginalMessageIdHeader] = originalMessageId
@@ -317,7 +320,9 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         {
             await EnsureTopicCreatedAsync(envelope.CancellationToken).AnyContext();
             await PublishMessageAsync(envelope.Exchange, envelope.RoutingKey, envelope.Body.ToArray(), properties, envelope.CancellationToken).AnyContext();
-            await _subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+
+            if (_subscriberChannel is { } ackChannel)
+                await ackChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
 
             _logger.LogDebug("Republished classic queue message ({MessageId}) (OriginalMessageId={OriginalMessageId}) with delivery count {DeliveryCount}",
                 envelope.BasicProperties.MessageId, originalMessageId, currentRetryCount + 1);
@@ -325,7 +330,9 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to republish message ({MessageId}), acknowledging to prevent infinite retry", envelope.BasicProperties.MessageId);
-            await _subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+
+            if (_subscriberChannel is { } fallbackChannel)
+                await fallbackChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
         }
     }
 
@@ -336,9 +343,9 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private static long GetRetryCountFromHeader(BasicDeliverEventArgs envelope)
     {
         long retryCount = 0;
-        if (envelope.BasicProperties.Headers?.TryGetValue(XDeliveryCountHeader, out object xDeliveryCount) is true)
+        if (envelope.BasicProperties.Headers?.TryGetValue(XDeliveryCountHeader, out object? xDeliveryCount) is true)
         {
-            if (!Int64.TryParse(xDeliveryCount.ToString(), out retryCount))
+            if (!Int64.TryParse(xDeliveryCount?.ToString(), out retryCount))
                 retryCount = 0;
         }
 
@@ -347,17 +354,17 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private static string GetOriginalMessageIdFromHeader(BasicDeliverEventArgs envelope)
     {
-        if (envelope.BasicProperties.Headers?.TryGetValue(XOriginalMessageIdHeader, out object xOriginalMessageId) is true)
+        if (envelope.BasicProperties.Headers?.TryGetValue(XOriginalMessageIdHeader, out object? xOriginalMessageId) is true)
         {
             return xOriginalMessageId switch
             {
                 string str => str,
                 byte[] bytes => Encoding.UTF8.GetString(bytes),
-                _ => xOriginalMessageId?.ToString()
+                _ => xOriginalMessageId?.ToString() ?? envelope.BasicProperties.MessageId ?? string.Empty
             };
         }
 
-        return envelope.BasicProperties.MessageId;
+        return envelope.BasicProperties.MessageId ?? string.Empty;
     }
 
     private async Task PublishMessageAsync(string exchange, string routingKey, byte[] body, BasicProperties properties, CancellationToken cancellationToken)
@@ -371,28 +378,31 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 if (_isPublisherBlocked)
                     throw new MessageBusException($"Cannot publish: publisher connection is blocked by broker ({_publisherBlockedReason ?? "resource alarm"})");
 
-                await _publisherChannel.BasicPublishAsync(exchange, routingKey, mandatory: false, properties, body, cancellationToken: cancellationToken);
+                await _publisherChannel!.BasicPublishAsync(exchange, routingKey, mandatory: false, properties, body, cancellationToken: cancellationToken);
             }, cancellationToken).AnyContext();
         }
     }
 
     protected virtual IMessage ConvertToMessage(BasicDeliverEventArgs envelope)
     {
+        var messageType = envelope.BasicProperties.Type;
         var message = new Message(envelope.Body.ToArray(), DeserializeMessageBody)
         {
-            Type = envelope.BasicProperties.Type,
-            ClrType = GetMappedMessageType(envelope.BasicProperties.Type),
+            Type = messageType ?? string.Empty,
             CorrelationId = envelope.BasicProperties.CorrelationId,
             UniqueId = envelope.BasicProperties.MessageId
         };
+
+        if (messageType is not null)
+            message.ClrType = GetMappedMessageType(messageType);
 
         if (envelope.BasicProperties.Headers is not null)
             foreach (var header in envelope.BasicProperties.Headers)
             {
                 if (header.Value is byte[] byteData)
                     message.Properties[header.Key] = Encoding.UTF8.GetString(byteData);
-                else
-                    message.Properties[header.Key] = header.Value.ToString();
+                else if (header.Value?.ToString() is { } stringValue)
+                    message.Properties[header.Key] = stringValue;
             }
 
         return message;
@@ -540,6 +550,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         {
             var mappedType = GetMappedMessageType(messageType);
             _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
+            if (mappedType is null)
+                throw new MessageBusException($"Unable to resolve CLR type for delayed message: {messageType}");
 
             SendDelayedMessage(mappedType, message, options);
             return;
@@ -559,7 +571,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
         if (options.Properties.Count > 0)
         {
-            basicProperties.Headers ??= new Dictionary<string, object>();
+            basicProperties.Headers ??= new Dictionary<string, object?>();
             foreach (var property in options.Properties)
                 basicProperties.Headers.Add(property.Key, property.Value);
         }
@@ -570,7 +582,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             // It's necessary to typecast long to int because RabbitMQ on the consumer side is reading the
             // data back as signed (using BinaryReader#ReadInt64). You will see the value to be negative
             // and the data will be delivered immediately.
-            basicProperties.Headers ??= new Dictionary<string, object>();
+            basicProperties.Headers ??= new Dictionary<string, object?>();
             basicProperties.Headers["x-delay"] = Convert.ToInt32(options.DeliveryDelay.Value.TotalMilliseconds);
             _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
         }
@@ -609,7 +621,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             // This exchange is a delayed exchange (fanout). You need rabbitmq_delayed_message_exchange plugin to RabbitMQ
             // Disclaimer: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/
             // Please read the *Performance Impact* of the delayed exchange type.
-            var args = new Dictionary<string, object> { { "x-delayed-type", ExchangeType.Fanout } };
+            var args = new Dictionary<string, object?> { { "x-delayed-type", ExchangeType.Fanout } };
             await channel.ExchangeDeclareAsync(_options.Topic, "x-delayed-message", _options.IsDurable, false, args).AnyContext();
         }
         catch (OperationInterruptedException ex)
@@ -793,7 +805,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     /// <summary>
     /// Parses a host string in format "hostname" or "hostname:port" into an AmqpTcpEndpoint.
     /// </summary>
-    private static AmqpTcpEndpoint ParseHostEndpoint(string host, int defaultPort)
+    private static AmqpTcpEndpoint? ParseHostEndpoint(string host, int defaultPort)
     {
         if (String.IsNullOrWhiteSpace(host))
             return null;
@@ -811,57 +823,57 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     private void RegisterPublisherConnectionEventHandlers()
     {
-        _publisherConnection.CallbackExceptionAsync += OnPublisherConnectionOnCallbackExceptionAsync;
-        _publisherConnection.ConnectionBlockedAsync += OnPublisherConnectionOnConnectionBlockedAsync;
-        _publisherConnection.ConnectionRecoveryErrorAsync += OnPublisherConnectionOnConnectionRecoveryErrorAsync;
-        _publisherConnection.ConnectionShutdownAsync += OnPublisherConnectionOnConnectionShutdownAsync;
-        _publisherConnection.ConnectionUnblockedAsync += OnPublisherConnectionOnConnectionUnblockedAsync;
-        _publisherConnection.RecoveringConsumerAsync += OnPublisherConnectionOnRecoveringConsumerAsync;
-        _publisherConnection.RecoverySucceededAsync += OnPublisherConnectionOnRecoverySucceededAsync;
+        _publisherConnection!.CallbackExceptionAsync += OnPublisherConnectionOnCallbackExceptionAsync;
+        _publisherConnection!.ConnectionBlockedAsync += OnPublisherConnectionOnConnectionBlockedAsync;
+        _publisherConnection!.ConnectionRecoveryErrorAsync += OnPublisherConnectionOnConnectionRecoveryErrorAsync;
+        _publisherConnection!.ConnectionShutdownAsync += OnPublisherConnectionOnConnectionShutdownAsync;
+        _publisherConnection!.ConnectionUnblockedAsync += OnPublisherConnectionOnConnectionUnblockedAsync;
+        _publisherConnection!.RecoveringConsumerAsync += OnPublisherConnectionOnRecoveringConsumerAsync;
+        _publisherConnection!.RecoverySucceededAsync += OnPublisherConnectionOnRecoverySucceededAsync;
     }
 
     private void UnregisterPublisherConnectionEventHandlers()
     {
-        _publisherConnection.CallbackExceptionAsync -= OnPublisherConnectionOnCallbackExceptionAsync;
-        _publisherConnection.ConnectionBlockedAsync -= OnPublisherConnectionOnConnectionBlockedAsync;
-        _publisherConnection.ConnectionRecoveryErrorAsync -= OnPublisherConnectionOnConnectionRecoveryErrorAsync;
-        _publisherConnection.ConnectionShutdownAsync -= OnPublisherConnectionOnConnectionShutdownAsync;
-        _publisherConnection.ConnectionUnblockedAsync -= OnPublisherConnectionOnConnectionUnblockedAsync;
-        _publisherConnection.RecoveringConsumerAsync -= OnPublisherConnectionOnRecoveringConsumerAsync;
-        _publisherConnection.RecoverySucceededAsync -= OnPublisherConnectionOnRecoverySucceededAsync;
+        _publisherConnection!.CallbackExceptionAsync -= OnPublisherConnectionOnCallbackExceptionAsync;
+        _publisherConnection!.ConnectionBlockedAsync -= OnPublisherConnectionOnConnectionBlockedAsync;
+        _publisherConnection!.ConnectionRecoveryErrorAsync -= OnPublisherConnectionOnConnectionRecoveryErrorAsync;
+        _publisherConnection!.ConnectionShutdownAsync -= OnPublisherConnectionOnConnectionShutdownAsync;
+        _publisherConnection!.ConnectionUnblockedAsync -= OnPublisherConnectionOnConnectionUnblockedAsync;
+        _publisherConnection!.RecoveringConsumerAsync -= OnPublisherConnectionOnRecoveringConsumerAsync;
+        _publisherConnection!.RecoverySucceededAsync -= OnPublisherConnectionOnRecoverySucceededAsync;
     }
 
     private void RegisterSubscriberConnectionEventHandlers()
     {
-        _subscriberConnection.CallbackExceptionAsync += OnSubscriberConnectionOnCallbackExceptionAsync;
-        _subscriberConnection.ConnectionBlockedAsync += OnSubscriberConnectionOnConnectionBlockedAsync;
-        _subscriberConnection.ConnectionRecoveryErrorAsync += OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
-        _subscriberConnection.ConnectionShutdownAsync += OnSubscriberConnectionOnConnectionShutdownAsync;
-        _subscriberConnection.ConnectionUnblockedAsync += OnSubscriberConnectionOnConnectionUnblockedAsync;
-        _subscriberConnection.RecoveringConsumerAsync += OnSubscriberConnectionOnRecoveringConsumerAsync;
-        _subscriberConnection.RecoverySucceededAsync += OnSubscriberConnectionOnRecoverySucceededAsync;
+        _subscriberConnection!.CallbackExceptionAsync += OnSubscriberConnectionOnCallbackExceptionAsync;
+        _subscriberConnection!.ConnectionBlockedAsync += OnSubscriberConnectionOnConnectionBlockedAsync;
+        _subscriberConnection!.ConnectionRecoveryErrorAsync += OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
+        _subscriberConnection!.ConnectionShutdownAsync += OnSubscriberConnectionOnConnectionShutdownAsync;
+        _subscriberConnection!.ConnectionUnblockedAsync += OnSubscriberConnectionOnConnectionUnblockedAsync;
+        _subscriberConnection!.RecoveringConsumerAsync += OnSubscriberConnectionOnRecoveringConsumerAsync;
+        _subscriberConnection!.RecoverySucceededAsync += OnSubscriberConnectionOnRecoverySucceededAsync;
     }
 
     private void UnregisterSubscriberConnectionEventHandlers()
     {
-        _subscriberConnection.CallbackExceptionAsync -= OnSubscriberConnectionOnCallbackExceptionAsync;
-        _subscriberConnection.ConnectionBlockedAsync -= OnSubscriberConnectionOnConnectionBlockedAsync;
-        _subscriberConnection.ConnectionRecoveryErrorAsync -= OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
-        _subscriberConnection.ConnectionShutdownAsync -= OnSubscriberConnectionOnConnectionShutdownAsync;
-        _subscriberConnection.ConnectionUnblockedAsync -= OnSubscriberConnectionOnConnectionUnblockedAsync;
-        _subscriberConnection.RecoveringConsumerAsync -= OnSubscriberConnectionOnRecoveringConsumerAsync;
-        _subscriberConnection.RecoverySucceededAsync -= OnSubscriberConnectionOnRecoverySucceededAsync;
+        _subscriberConnection!.CallbackExceptionAsync -= OnSubscriberConnectionOnCallbackExceptionAsync;
+        _subscriberConnection!.ConnectionBlockedAsync -= OnSubscriberConnectionOnConnectionBlockedAsync;
+        _subscriberConnection!.ConnectionRecoveryErrorAsync -= OnSubscriberConnectionOnConnectionRecoveryErrorAsync;
+        _subscriberConnection!.ConnectionShutdownAsync -= OnSubscriberConnectionOnConnectionShutdownAsync;
+        _subscriberConnection!.ConnectionUnblockedAsync -= OnSubscriberConnectionOnConnectionUnblockedAsync;
+        _subscriberConnection!.RecoveringConsumerAsync -= OnSubscriberConnectionOnRecoveringConsumerAsync;
+        _subscriberConnection!.RecoverySucceededAsync -= OnSubscriberConnectionOnRecoverySucceededAsync;
     }
 
     private void RegisterConsumerEventHandlers()
     {
-        _consumer.ReceivedAsync += OnMessageAsync;
-        _consumer.ShutdownAsync += OnConsumerShutdownAsync;
+        _consumer!.ReceivedAsync += OnMessageAsync;
+        _consumer!.ShutdownAsync += OnConsumerShutdownAsync;
     }
 
     private void UnregisterConsumerEventHandlers()
     {
-        _consumer.ReceivedAsync -= OnMessageAsync;
-        _consumer.ShutdownAsync -= OnConsumerShutdownAsync;
+        _consumer!.ReceivedAsync -= OnMessageAsync;
+        _consumer!.ShutdownAsync -= OnConsumerShutdownAsync;
     }
 }

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -194,7 +194,11 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task OnMessageAsync(object sender, BasicDeliverEventArgs envelope)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-            throw new MessageBusException("Subscriber channel is not available. Cannot process message.");
+        {
+            _logger.LogDebug("Ignoring message because subscriber channel is not available ({MessageId})",
+                envelope.BasicProperties?.MessageId);
+            return;
+        }
 
         using var _ = _logger.BeginScope(s => s
             .Property("MessageId", envelope.BasicProperties.MessageId)
@@ -305,7 +309,11 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task RepublishMessageWithIncrementedDeliveryCountAsync(BasicDeliverEventArgs envelope, long currentRetryCount)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-            throw new MessageBusException("Subscriber channel is not available. Cannot republish message.");
+        {
+            _logger.LogWarning("Skipping republish for message ({MessageId}) because the subscriber channel is unavailable; leaving message unacknowledged for broker redelivery",
+                envelope.BasicProperties.MessageId);
+            return;
+        }
 
         string? originalMessageId = GetOriginalMessageIdFromHeader(envelope);
         var properties = new BasicProperties(envelope.BasicProperties)

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -35,7 +35,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     public RabbitMQMessageBus(RabbitMQMessageBusOptions options) : base(options)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString, nameof(options.ConnectionString));
+        ArgumentException.ThrowIfNullOrWhiteSpace(options?.ConnectionString, nameof(options.ConnectionString));
 
         if (!Uri.TryCreate(options.ConnectionString, UriKind.Absolute, out var primaryUri))
             throw new ArgumentException($"ConnectionString is not a valid URI: {options.ConnectionString}");
@@ -194,10 +194,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task OnMessageAsync(object sender, BasicDeliverEventArgs envelope)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-        {
-            _logger.LogWarning("Subscriber channel is not available, skipping {Operation} for message ({MessageId})", nameof(OnMessageAsync), envelope.BasicProperties.MessageId);
-            return;
-        }
+            throw new MessageBusException("Subscriber channel is not available. Cannot process message.");
 
         using var _ = _logger.BeginScope(s => s
             .Property("MessageId", envelope.BasicProperties.MessageId)
@@ -239,10 +236,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task HandleDeliveryLimitsAsync(BasicDeliverEventArgs envelope)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-        {
-            _logger.LogWarning("Subscriber channel is not available, skipping {Operation} for message ({MessageId})", nameof(HandleDeliveryLimitsAsync), envelope.BasicProperties.MessageId);
-            return;
-        }
+            throw new MessageBusException("Subscriber channel is not available. Cannot handle delivery limits.");
 
         // Rule 1: If the limit is negative, reject regardless of queue type
         if (_options.DeliveryLimit < 0)
@@ -308,12 +302,9 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task RepublishMessageWithIncrementedDeliveryCountAsync(BasicDeliverEventArgs envelope, long currentRetryCount)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-        {
-            _logger.LogWarning("Subscriber channel is not available, skipping {Operation} for message ({MessageId}); leaving unacknowledged for broker redelivery", nameof(RepublishMessageWithIncrementedDeliveryCountAsync), envelope.BasicProperties.MessageId);
-            return;
-        }
+            throw new MessageBusException("Subscriber channel is not available. Cannot republish message.");
 
-        string originalMessageId = GetOriginalMessageIdFromHeader(envelope);
+        string? originalMessageId = GetOriginalMessageIdFromHeader(envelope);
         var properties = new BasicProperties(envelope.BasicProperties)
         {
             MessageId = Guid.NewGuid().ToString("N")
@@ -362,7 +353,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         return retryCount;
     }
 
-    private static string GetOriginalMessageIdFromHeader(BasicDeliverEventArgs envelope)
+    private static string? GetOriginalMessageIdFromHeader(BasicDeliverEventArgs envelope)
     {
         if (envelope.BasicProperties.Headers?.TryGetValue(XOriginalMessageIdHeader, out object? xOriginalMessageId) is true)
         {
@@ -370,26 +361,23 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             {
                 string str => str,
                 byte[] bytes => Encoding.UTF8.GetString(bytes),
-                null => envelope.BasicProperties.MessageId ?? String.Empty,
-                _ => xOriginalMessageId.ToString() ?? envelope.BasicProperties.MessageId ?? String.Empty
+                null => envelope.BasicProperties.MessageId,
+                _ => xOriginalMessageId.ToString() ?? envelope.BasicProperties.MessageId
             };
         }
 
-        return envelope.BasicProperties.MessageId ?? String.Empty;
+        return envelope.BasicProperties.MessageId;
     }
 
     private async Task PublishMessageAsync(string exchange, string routingKey, byte[] body, BasicProperties properties, CancellationToken cancellationToken)
     {
         using (await _lock.LockAsync(cancellationToken).AnyContext())
         {
-            var channel = _publisherChannel;
-            if (channel is null)
+            if (_publisherChannel is not { } channel)
                 throw new MessageBusException("Cannot publish: publisher channel was closed.");
 
             await _resiliencePolicy.ExecuteAsync(async _ =>
             {
-                // Check blocked state inside resilience policy - re-evaluated on each retry
-                // MessageBusException is excluded from retries in the base class policy
                 if (_isPublisherBlocked)
                     throw new MessageBusException($"Cannot publish: publisher connection is blocked by broker ({_publisherBlockedReason ?? "resource alarm"})");
 
@@ -413,8 +401,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             {
                 if (header.Value is byte[] byteData)
                     message.Properties[header.Key] = Encoding.UTF8.GetString(byteData);
-                else
-                    message.Properties[header.Key] = header.Value?.ToString() ?? String.Empty;
+                else if (header.Value?.ToString() is { } stringValue)
+                    message.Properties[header.Key] = stringValue;
             }
 
         return message;
@@ -560,8 +548,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         // if the RabbitMQ plugin is not available, then use the base class delay mechanism
         if (_delayedExchangePluginEnabled is false && options.DeliveryDelay.HasValue && options.DeliveryDelay.Value > TimeSpan.Zero)
         {
-            var mappedType = GetMappedMessageType(messageType);
             _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
+            var mappedType = GetMappedMessageType(messageType);
             if (mappedType is null)
                 throw new MessageBusException($"Unable to resolve CLR type for delayed message: {messageType}");
 
@@ -834,7 +822,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private void RegisterPublisherConnectionEventHandlers()
     {
         if (_publisherConnection is null)
-            throw new InvalidOperationException("Publisher connection must be initialized before registering event handlers.");
+            throw new MessageBusException("Publisher connection must be initialized before registering event handlers.");
 
         _publisherConnection.CallbackExceptionAsync += OnPublisherConnectionOnCallbackExceptionAsync;
         _publisherConnection.ConnectionBlockedAsync += OnPublisherConnectionOnConnectionBlockedAsync;
@@ -848,7 +836,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private void UnregisterPublisherConnectionEventHandlers()
     {
         if (_publisherConnection is null)
-            throw new InvalidOperationException("Publisher connection must be initialized before unregistering event handlers.");
+            throw new MessageBusException("Publisher connection must be initialized before unregistering event handlers.");
 
         _publisherConnection.CallbackExceptionAsync -= OnPublisherConnectionOnCallbackExceptionAsync;
         _publisherConnection.ConnectionBlockedAsync -= OnPublisherConnectionOnConnectionBlockedAsync;
@@ -862,7 +850,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private void RegisterSubscriberConnectionEventHandlers()
     {
         if (_subscriberConnection is null)
-            throw new InvalidOperationException("Subscriber connection must be initialized before registering event handlers.");
+            throw new MessageBusException("Subscriber connection must be initialized before registering event handlers.");
 
         _subscriberConnection.CallbackExceptionAsync += OnSubscriberConnectionOnCallbackExceptionAsync;
         _subscriberConnection.ConnectionBlockedAsync += OnSubscriberConnectionOnConnectionBlockedAsync;
@@ -876,7 +864,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private void UnregisterSubscriberConnectionEventHandlers()
     {
         if (_subscriberConnection is null)
-            throw new InvalidOperationException("Subscriber connection must be initialized before unregistering event handlers.");
+            throw new MessageBusException("Subscriber connection must be initialized before unregistering event handlers.");
 
         _subscriberConnection.CallbackExceptionAsync -= OnSubscriberConnectionOnCallbackExceptionAsync;
         _subscriberConnection.ConnectionBlockedAsync -= OnSubscriberConnectionOnConnectionBlockedAsync;
@@ -890,7 +878,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private void RegisterConsumerEventHandlers()
     {
         if (_consumer is null)
-            throw new InvalidOperationException("Consumer must be initialized before registering event handlers.");
+            throw new MessageBusException("Consumer must be initialized before registering event handlers.");
 
         _consumer.ReceivedAsync += OnMessageAsync;
         _consumer.ShutdownAsync += OnConsumerShutdownAsync;
@@ -899,7 +887,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private void UnregisterConsumerEventHandlers()
     {
         if (_consumer is null)
-            throw new InvalidOperationException("Consumer must be initialized before unregistering event handlers.");
+            throw new MessageBusException("Consumer must be initialized before unregistering event handlers.");
 
         _consumer.ReceivedAsync -= OnMessageAsync;
         _consumer.ShutdownAsync -= OnConsumerShutdownAsync;

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -381,18 +381,20 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task PublishMessageAsync(string exchange, string routingKey, byte[] body, BasicProperties properties, CancellationToken cancellationToken)
     {
         if (_publisherChannel is null)
-            throw new InvalidOperationException("Publisher channel must be initialized before publishing messages.");
+            throw new MessageBusException("Publisher channel must be initialized before publishing messages.");
 
         using (await _lock.LockAsync(cancellationToken).AnyContext())
         {
+            var channel = _publisherChannel;
+            if (channel is null)
+                throw new MessageBusException("Cannot publish: publisher channel was closed.");
+
             await _resiliencePolicy.ExecuteAsync(async _ =>
             {
-                // Check blocked state inside resilience policy - re-evaluated on each retry
-                // MessageBusException is excluded from retries in the base class policy
                 if (_isPublisherBlocked)
                     throw new MessageBusException($"Cannot publish: publisher connection is blocked by broker ({_publisherBlockedReason ?? "resource alarm"})");
 
-                await _publisherChannel.BasicPublishAsync(exchange, routingKey, mandatory: false, properties, body, cancellationToken: cancellationToken);
+                await channel.BasicPublishAsync(exchange, routingKey, mandatory: false, properties, body, cancellationToken: cancellationToken);
             }, cancellationToken).AnyContext();
         }
     }

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -195,7 +195,10 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task OnMessageAsync(object sender, BasicDeliverEventArgs envelope)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-            throw new InvalidOperationException("Subscriber channel is not initialized.");
+        {
+            _logger.LogWarning("Subscriber channel is not available, skipping {Operation} for message ({MessageId})", nameof(OnMessageAsync), envelope.BasicProperties.MessageId);
+            return;
+        }
 
         using var _ = _logger.BeginScope(s => s
             .Property("MessageId", envelope.BasicProperties.MessageId)
@@ -236,7 +239,10 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task HandleDeliveryLimitsAsync(BasicDeliverEventArgs envelope)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-            throw new InvalidOperationException("Subscriber channel is not initialized.");
+        {
+            _logger.LogWarning("Subscriber channel is not available, skipping {Operation} for message ({MessageId})", nameof(HandleDeliveryLimitsAsync), envelope.BasicProperties.MessageId);
+            return;
+        }
 
         // Rule 1: If the limit is negative, reject regardless of queue type
         if (_options.DeliveryLimit < 0)
@@ -302,7 +308,10 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private async Task RepublishMessageWithIncrementedDeliveryCountAsync(BasicDeliverEventArgs envelope, long currentRetryCount)
     {
         if (_subscriberChannel is not { } subscriberChannel)
-            throw new InvalidOperationException("Subscriber channel is not initialized.");
+        {
+            _logger.LogWarning("Subscriber channel is not available, skipping {Operation} for message ({MessageId}); leaving unacknowledged for broker redelivery", nameof(RepublishMessageWithIncrementedDeliveryCountAsync), envelope.BasicProperties.MessageId);
+            return;
+        }
 
         string originalMessageId = GetOriginalMessageIdFromHeader(envelope);
         var properties = new BasicProperties(envelope.BasicProperties)

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -224,6 +224,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         }
         catch (MessageBusException)
         {
+            // SendMessageToSubscribersAsync already logged the error
             if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
                 await HandleDeliveryLimitsAsync(envelope).AnyContext();
         }
@@ -387,6 +388,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
             await _resiliencePolicy.ExecuteAsync(async _ =>
             {
+                // Check blocked state inside resilience policy - re-evaluated on each retry
+                // MessageBusException is excluded from retries in the base class policy
                 if (_isPublisherBlocked)
                     throw new MessageBusException($"Cannot publish: publisher connection is blocked by broker ({_publisherBlockedReason ?? "resource alarm"})");
 

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -360,7 +360,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             {
                 string str => str,
                 byte[] bytes => Encoding.UTF8.GetString(bytes),
-                _ => xOriginalMessageId?.ToString() ?? envelope.BasicProperties.MessageId ?? string.Empty
+                null => envelope.BasicProperties.MessageId ?? string.Empty,
+                _ => xOriginalMessageId.ToString() ?? envelope.BasicProperties.MessageId ?? string.Empty
             };
         }
 
@@ -386,6 +387,9 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     protected virtual IMessage ConvertToMessage(BasicDeliverEventArgs envelope)
     {
         var messageType = envelope.BasicProperties.Type;
+        if (String.IsNullOrEmpty(messageType))
+            _logger.LogTrace("Received message without a Type header ({MessageId})", envelope.BasicProperties.MessageId);
+
         var message = new Message(envelope.Body.ToArray(), DeserializeMessageBody)
         {
             Type = messageType ?? string.Empty,

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -378,6 +378,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
             await _resiliencePolicy.ExecuteAsync(async _ =>
             {
+                // Check blocked state inside resilience policy - re-evaluated on each retry
+                // MessageBusException is excluded from retries in the base class policy
                 if (_isPublisherBlocked)
                     throw new MessageBusException($"Cannot publish: publisher connection is blocked by broker ({_publisherBlockedReason ?? "resource alarm"})");
 

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBusOptions.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBusOptions.cs
@@ -9,7 +9,7 @@ public class RabbitMQMessageBusOptions : SharedMessageBusOptions
     /// The connection string. See https://www.rabbitmq.com/uri-spec.html for more information.
     /// Provides credentials and vhost. When Hosts is specified, the host in the connection string is ignored.
     /// </summary>
-    public string ConnectionString { get; set; } = null!;
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// List of hosts for failover. When specified, the client will try each host in order until one succeeds.

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBusOptions.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBusOptions.cs
@@ -9,14 +9,14 @@ public class RabbitMQMessageBusOptions : SharedMessageBusOptions
     /// The connection string. See https://www.rabbitmq.com/uri-spec.html for more information.
     /// Provides credentials and vhost. When Hosts is specified, the host in the connection string is ignored.
     /// </summary>
-    public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; } = null!;
 
     /// <summary>
     /// List of hosts for failover. When specified, the client will try each host in order until one succeeds.
     /// Format: "hostname" or "hostname:port" (default port is 5672, or 5671 for amqps).
     /// If not specified, the host from ConnectionString is used.
     /// </summary>
-    public IList<string> Hosts { get; set; }
+    public IList<string>? Hosts { get; set; }
 
     /// <summary>
     /// The default message time to live. The value of the expiration field describes the TTL period in milliseconds.
@@ -26,7 +26,7 @@ public class RabbitMQMessageBusOptions : SharedMessageBusOptions
     /// <summary>
     /// Arguments passed to QueueDeclare. Some brokers use it to implement additional features like message TTL.
     /// </summary>
-    public IDictionary<string, object> Arguments { get; set; }
+    public IDictionary<string, object?>? Arguments { get; set; }
 
     /// <summary>
     /// Durable (will survive a broker restart)
@@ -125,7 +125,7 @@ public class RabbitMQMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<R
         return this;
     }
 
-    public RabbitMQMessageBusOptionsBuilder Arguments(IDictionary<string, object> arguments)
+    public RabbitMQMessageBusOptionsBuilder Arguments(IDictionary<string, object?> arguments)
     {
         Target.Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
         return this;
@@ -183,7 +183,7 @@ public class RabbitMQMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<R
     {
         Target.DeliveryLimit = deliveryLimit;
 
-        Target.Arguments ??= new Dictionary<string, object>();
+        Target.Arguments ??= new Dictionary<string, object?>();
         Target.Arguments["x-delivery-limit"] = deliveryLimit;
 
         return this;
@@ -214,7 +214,7 @@ public class RabbitMQMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<R
         Target.SubscriptionQueueAutoDelete = false;
         Target.IsSubscriptionQueueExclusive = false;
 
-        Target.Arguments ??= new Dictionary<string, object>();
+        Target.Arguments ??= new Dictionary<string, object?>();
 
         // Add or update quorum-specific arguments
         Target.Arguments["x-queue-type"] = "quorum";

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusClassicTestBase.cs
+++ b/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusClassicTestBase.cs
@@ -15,7 +15,7 @@ public abstract class RabbitMqMessageBusClassicTestBase : RabbitMqMessageBusTest
     }
 
 
-    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions> config = null)
+    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions>? config = null)
     {
         return new RabbitMQMessageBus(o =>
         {

--- a/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
+++ b/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
@@ -15,7 +15,7 @@ public abstract class RabbitMqMessageBusTestBase(string connectionString, ITestO
     private readonly string _topic = $"test_topic_{DateTime.UtcNow.Ticks}";
     protected readonly string ConnectionString = connectionString;
 
-    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions> config = null)
+    protected override IMessageBus GetMessageBus(Func<SharedMessageBusOptions, SharedMessageBusOptions>? config = null)
     {
         return new RabbitMQMessageBus(o =>
         {


### PR DESCRIPTION
## Summary
- Enabled project-wide nullable reference types (`<Nullable>enable</Nullable>`) in `build/common.props`
- Replaced ineffective `<WarningsAsErrors>true</WarningsAsErrors>` with correct `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
- Fixed all NRT warnings across `RabbitMQMessageBus`, options, and samples
- Bumped Foundatio/TestHarness package versions to `13.0.0-beta3.41` for base class disposal guards

## Changes
- **build/common.props**: Enabled `<Nullable>enable</Nullable>`, switched `WarningsAsErrors` -> `TreatWarningsAsErrors`
- **RabbitMQMessageBus.cs**: Null-safe envelope property access, local capture pattern for `_subscriberChannel`/`_publisherChannel` to handle disposal races, guard clauses for Register/Unregister methods, `ThrowIfNullOrWhiteSpace` for ConnectionString, removed redundant `_factory` null checks in Dispose
- **RabbitMQMessageBusOptions.cs**: `ConnectionString` annotated as `string?` (validated at runtime), `Arguments` as `IDictionary<string, object?>?` matching RabbitMQ 7.x client
- **Samples**: Proper `string?` locals with `ThrowIfNullOrWhiteSpace` validation instead of `!` operators and fallbacks
- **Package versions**: Foundatio/TestHarness bumped to `13.0.0-beta3.41`

## Test plan
- [x] `dotnet build Foundatio.RabbitMQ.slnx` -- 0 warnings, 0 errors
- [x] All previously resolved PR review threads remain addressed
