### PR TITLE
Add version-gated deprecation handling for rabbitmq_delayed_message_exchange plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Foundatio.RabbitMQ supports delayed message delivery via the `DeliveryDelay` opt
 
 **Current behavior:**
 
-1. **RabbitMQ < 4.3 with plugin installed**: If the [`rabbitmq_delayed_message_exchange`](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/) plugin is detected, it is used for delay delivery. A warning is logged because the plugin is deprecated and will not work on RabbitMQ 4.3+.
+1. **RabbitMQ < 4.3 with plugin installed**: If the [`rabbitmq_delayed_message_exchange`](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/) plugin is detected, it is used for delayed delivery. A warning is logged because the plugin is deprecated and will not work on RabbitMQ 4.3+.
 2. **RabbitMQ < 4.3 without plugin**: Falls back to an in-memory delay scheduler provided by `MessageBusBase`. Messages are held in process memory and delivered after the delay. **This is not durable** -- delayed messages are lost if the process restarts.
 3. **RabbitMQ >= 4.3**: The plugin probe is skipped entirely (the plugin depends on Mnesia, which was removed in 4.3). The in-memory fallback is used automatically.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Foundatio.RabbitMQ supports delayed message delivery via the `DeliveryDelay` opt
 
 1. **RabbitMQ < 4.3 with plugin installed**: If the [`rabbitmq_delayed_message_exchange`](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/) plugin is detected, it is used for delayed delivery. A warning is logged because the plugin is deprecated and will not work on RabbitMQ 4.3+.
 2. **RabbitMQ < 4.3 without plugin**: Falls back to an in-memory delay scheduler provided by `MessageBusBase`. Messages are held in process memory and delivered after the delay. **This is not durable** -- delayed messages are lost if the process restarts.
-3. **RabbitMQ >= 4.3**: The plugin probe is skipped entirely (the plugin depends on Mnesia, which was removed in 4.3). The in-memory fallback is used automatically.
+3. **When the RabbitMQ server version is detected as >= 4.3**: The plugin probe is skipped (the plugin depends on Mnesia, which was removed in 4.3), and the in-memory fallback is used automatically. If the server version cannot be determined from `ServerProperties["version"]`, the probe may still be attempted before falling back.
 
 **Migration guidance:**
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ await messageBus.PublishAsync(new MyMessage { Data = "Hello" });
 
 **👉 [Complete Documentation](https://foundatio.dev)**
 
+### Delayed Message Delivery
+
+Foundatio.RabbitMQ supports delayed message delivery via the `DeliveryDelay` option on `PublishAsync`.
+
+**Current behavior:**
+
+1. **RabbitMQ < 4.3 with plugin installed**: If the [`rabbitmq_delayed_message_exchange`](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/) plugin is detected, it is used for delay delivery. A warning is logged because the plugin is deprecated and will not work on RabbitMQ 4.3+.
+2. **RabbitMQ < 4.3 without plugin**: Falls back to an in-memory delay scheduler provided by `MessageBusBase`. Messages are held in process memory and delivered after the delay. **This is not durable** -- delayed messages are lost if the process restarts.
+3. **RabbitMQ >= 4.3**: The plugin probe is skipped entirely (the plugin depends on Mnesia, which was removed in 4.3). The in-memory fallback is used automatically.
+
+**Migration guidance:**
+
+The `rabbitmq_delayed_message_exchange` plugin is [archived and no longer maintained](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/). RabbitMQ 4.3 removes Mnesia, making the plugin incompatible. If you rely on delayed messages:
+
+- On RabbitMQ < 4.3: The plugin still works but logs a deprecation warning at startup.
+- On RabbitMQ >= 4.3: Delayed messages use the in-memory fallback automatically. Be aware that these are not durable across process restarts.
+- For durable delayed delivery on RabbitMQ 4.3+, consider implementing TTL + Dead-Letter Exchange patterns or using an external scheduler.
+
 ### Core Features
 
 - [Getting Started](https://foundatio.dev/guide/getting-started) - Installation and setup

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -457,6 +457,10 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 _publisherChannel = await _publisherConnection.CreateChannelAsync(cancellationToken: cancellationToken).AnyContext();
             }
 
+            // We first attempt to create "x-delayed-type". For this the rabbitmq_delayed_message_exchange plugin should be installed.
+            // However, if the plugin is not installed this will throw an exception. In that case
+            // we attempt to create a regular exchange. If the regular exchange also throws an exception
+            // then troubleshoot the problem.
             if (!await CreateDelayedExchangeAsync(_publisherChannel).AnyContext())
             {
                 // if the initial exchange creation was not successful, then we must close the previous connection
@@ -614,6 +618,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     /// <returns></returns>
     private Task<IConnection> CreateConnectionAsync()
     {
+        // Use multiple endpoints for failover support
         return _factory.CreateConnectionAsync(_endpoints);
     }
 
@@ -627,9 +632,12 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             return;
 
         _serverVersion = version;
-        _logger.LogInformation("Connected to RabbitMQ server version {ServerVersion}", version);
+        _logger.LogDebug("Connected to RabbitMQ server version {ServerVersion}", version);
     }
 
+    /// <summary>
+    /// Parses the RabbitMQ broker version from AMQP server properties (the <c>version</c> field is UTF-8 bytes).
+    /// </summary>
     public static Version? ParseServerVersion(IDictionary<string, object?>? serverProperties)
     {
         if (serverProperties?.TryGetValue("version", out var versionObj) is not true
@@ -661,6 +669,10 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         bool success = true;
         try
         {
+            // This exchange is a delayed exchange (fanout). You need the rabbitmq_delayed_message_exchange plugin on RabbitMQ.
+            // Disclaimer: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/
+            // Please read the *Performance Impact* of the delayed exchange type.
+            // On RabbitMQ 4.3+ this probe is skipped (see method summary); the plugin is incompatible.
             var args = new Dictionary<string, object?> { { "x-delayed-type", ExchangeType.Fanout } };
             await channel.ExchangeDeclareAsync(_options.Topic, "x-delayed-message", _options.IsDurable, false, args).AnyContext();
         }

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -711,7 +711,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         }
 
         _delayedExchangePluginEnabled = success;
-        return success ? true : false;
+        return success;
     }
 
     private Task CreateRegularExchangeAsync(IChannel channel)

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -111,7 +111,12 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             _subscriberChannel = await _subscriberConnection.CreateChannelAsync(cancellationToken: cancellationToken).AnyContext();
 
             // If InitPublisher is called first, then we will never come in this if-clause.
-            if (!await CreateDelayedExchangeAsync(_subscriberChannel).AnyContext())
+            var delayedExchangeResult = await CreateDelayedExchangeAsync(_subscriberChannel).AnyContext();
+            if (delayedExchangeResult is null)
+            {
+                await CreateRegularExchangeAsync(_subscriberChannel).AnyContext();
+            }
+            else if (delayedExchangeResult is false)
             {
                 await _subscriberChannel.DisposeAsync().AnyContext();
                 UnregisterSubscriberConnectionEventHandlers();
@@ -462,7 +467,12 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             // However, if the plugin is not installed this will throw an exception. In that case
             // we attempt to create a regular exchange. If the regular exchange also throws an exception
             // then troubleshoot the problem.
-            if (!await CreateDelayedExchangeAsync(_publisherChannel).AnyContext())
+            var delayedExchangeResult = await CreateDelayedExchangeAsync(_publisherChannel).AnyContext();
+            if (delayedExchangeResult is null)
+            {
+                await CreateRegularExchangeAsync(_publisherChannel).AnyContext();
+            }
+            else if (delayedExchangeResult is false)
             {
                 // if the initial exchange creation was not successful, then we must close the previous connection
                 // and establish the new client connection and model; otherwise you will keep receiving failure in creation
@@ -654,11 +664,15 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     /// rabbitmq_delayed_message_exchange plugin depends on Mnesia which was removed. When the server
     /// version could not be determined, the probe is still attempted so the plugin is used if available.
     /// </summary>
-    /// <returns>true if the delayed exchange was successfully declared, meaning the plugin is installed.</returns>
-    private async Task<bool> CreateDelayedExchangeAsync(IChannel channel)
+    /// <returns>
+    /// <c>true</c> if the delayed exchange was successfully declared (plugin is installed);
+    /// <c>null</c> if the probe was skipped or the result was already cached as disabled (the channel is still healthy);
+    /// <c>false</c> if the probe threw and the channel is likely closed.
+    /// </returns>
+    private async Task<bool?> CreateDelayedExchangeAsync(IChannel channel)
     {
         if (_delayedExchangePluginEnabled.HasValue)
-            return _delayedExchangePluginEnabled.Value;
+            return _delayedExchangePluginEnabled.Value ? true : null;
 
         if (_serverVersion is not null && _serverVersion >= _delayedExchangePluginIncompatibleVersion)
         {
@@ -666,7 +680,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 "Skipping delayed exchange plugin probe: RabbitMQ {ServerVersion} removed Mnesia, plugin is incompatible",
                 _serverVersion);
             _delayedExchangePluginEnabled = false;
-            return false;
+            return null;
         }
 
         bool success = true;
@@ -681,7 +695,12 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         }
         catch (OperationInterruptedException ex)
         {
-            _logger.LogInformation(ex, "Delayed exchange plugin not available: {Message}", ex.Message);
+            _logger.LogInformation(
+                ex,
+                "Unable to declare delayed exchange. ReplyCode: {ReplyCode}, ReplyText: {ReplyText}, Message: {Message}",
+                ex.ShutdownReason?.ReplyCode,
+                ex.ShutdownReason?.ReplyText,
+                ex.Message);
             success = false;
         }
 
@@ -692,7 +711,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         }
 
         _delayedExchangePluginEnabled = success;
-        return success;
+        return success ? true : false;
     }
 
     private Task CreateRegularExchangeAsync(IChannel channel)

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -18,6 +18,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 {
     private const string XDeliveryCountHeader = "x-delivery-count";
     private const string XOriginalMessageIdHeader = "x-original-message-id";
+    private static readonly Version _delayedExchangePluginIncompatibleVersion = new(4, 3);
 
     private readonly AsyncLock _lock = new();
     private readonly ConnectionFactory _factory;
@@ -28,6 +29,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private IChannel? _subscriberChannel;
     private AsyncEventingBasicConsumer? _consumer;
     private bool? _delayedExchangePluginEnabled;
+    private Version? _serverVersion;
     private readonly bool _isQuorumQueue;
     private bool _isDisposed;
     private volatile bool _isPublisherBlocked;
@@ -103,6 +105,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 return;
 
             _subscriberConnection = await CreateConnectionAsync().AnyContext();
+            DetectServerVersion(_subscriberConnection);
             RegisterSubscriberConnectionEventHandlers();
 
             _subscriberChannel = await _subscriberConnection.CreateChannelAsync(cancellationToken: cancellationToken).AnyContext();
@@ -435,6 +438,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
             // the exchange with the publisher queue. It requires the name of our exchange, exchange type, durability and auto-delete.
             // For now, we are using same autoDelete for both exchange and queue (it will survive a server restart)
             _publisherConnection = await CreateConnectionAsync().AnyContext();
+            DetectServerVersion(_publisherConnection);
             RegisterPublisherConnectionEventHandlers();
 
             // Reset blocked state after handlers are registered - new connections start unblocked
@@ -453,10 +457,6 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 _publisherChannel = await _publisherConnection.CreateChannelAsync(cancellationToken: cancellationToken).AnyContext();
             }
 
-            // We first attempt to create "x-delayed-type". For this plugin should be installed.
-            // However, we plug in is not installed this will throw an exception. In that case
-            // we attempt to create regular exchange. If regular exchange also throws and exception
-            // then troubleshoot the problem.
             if (!await CreateDelayedExchangeAsync(_publisherChannel).AnyContext())
             {
                 // if the initial exchange creation was not successful, then we must close the previous connection
@@ -614,37 +614,70 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     /// <returns></returns>
     private Task<IConnection> CreateConnectionAsync()
     {
-        // Use multiple endpoints for failover support
         return _factory.CreateConnectionAsync(_endpoints);
     }
 
+    private void DetectServerVersion(IConnection connection)
+    {
+        if (_serverVersion is not null)
+            return;
+
+        var version = ParseServerVersion(connection.ServerProperties);
+        if (version is null)
+            return;
+
+        _serverVersion = version;
+        _logger.LogInformation("Connected to RabbitMQ server version {ServerVersion}", version);
+    }
+
+    public static Version? ParseServerVersion(IDictionary<string, object?>? serverProperties)
+    {
+        if (serverProperties?.TryGetValue("version", out var versionObj) is not true
+            || versionObj is not byte[] bytes)
+            return null;
+
+        return Version.TryParse(Encoding.UTF8.GetString(bytes), out var version) ? version : null;
+    }
+
     /// <summary>
-    /// Attempts to create the delayed exchange.
+    /// Attempts to create the delayed exchange. On RabbitMQ 4.3+ the probe is skipped because the
+    /// rabbitmq_delayed_message_exchange plugin depends on Mnesia which was removed.
     /// </summary>
-    /// <param name="channel"></param>
-    /// <returns>true if the delayed exchange was successfully declared. Which means plugin was installed.</returns>
+    /// <returns>true if the delayed exchange was successfully declared, meaning the plugin is installed.</returns>
     private async Task<bool> CreateDelayedExchangeAsync(IChannel channel)
     {
-        bool success = true;
         if (_delayedExchangePluginEnabled.HasValue)
             return _delayedExchangePluginEnabled.Value;
 
+        if (_serverVersion is not null && _serverVersion >= _delayedExchangePluginIncompatibleVersion)
+        {
+            _logger.LogInformation(
+                "Skipping delayed exchange plugin probe: RabbitMQ {ServerVersion} removed Mnesia, plugin is incompatible",
+                _serverVersion);
+            _delayedExchangePluginEnabled = false;
+            return false;
+        }
+
+        bool success = true;
         try
         {
-            // This exchange is a delayed exchange (fanout). You need rabbitmq_delayed_message_exchange plugin to RabbitMQ
-            // Disclaimer: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/
-            // Please read the *Performance Impact* of the delayed exchange type.
             var args = new Dictionary<string, object?> { { "x-delayed-type", ExchangeType.Fanout } };
             await channel.ExchangeDeclareAsync(_options.Topic, "x-delayed-message", _options.IsDurable, false, args).AnyContext();
         }
         catch (OperationInterruptedException ex)
         {
-            _logger.LogInformation(ex, "Unable to create x-delayed-type exchange: {Message}", ex.Message);
+            _logger.LogInformation(ex, "Delayed exchange plugin not available: {Message}", ex.Message);
             success = false;
         }
 
+        if (success)
+        {
+            _logger.LogWarning(
+                "The rabbitmq_delayed_message_exchange plugin is deprecated and incompatible with RabbitMQ 4.3+. See https://github.com/rabbitmq/rabbitmq-delayed-message-exchange for details. Plan migration before upgrading to RabbitMQ 4.3");
+        }
+
         _delayedExchangePluginEnabled = success;
-        return _delayedExchangePluginEnabled.Value;
+        return success;
     }
 
     private Task CreateRegularExchangeAsync(IChannel channel)

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -118,6 +118,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 await _subscriberConnection.DisposeAsync().AnyContext();
 
                 _subscriberConnection = await CreateConnectionAsync().AnyContext();
+                DetectServerVersion(_subscriberConnection);
                 RegisterSubscriberConnectionEventHandlers();
 
                 _subscriberChannel = await _subscriberConnection.CreateChannelAsync(cancellationToken: cancellationToken).AnyContext();
@@ -471,6 +472,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
                 await _publisherConnection.DisposeAsync().AnyContext();
 
                 _publisherConnection = await CreateConnectionAsync().AnyContext();
+                DetectServerVersion(_publisherConnection);
                 RegisterPublisherConnectionEventHandlers();
 
                 // Reset blocked state after handlers are registered
@@ -649,7 +651,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
     /// <summary>
     /// Attempts to create the delayed exchange. On RabbitMQ 4.3+ the probe is skipped because the
-    /// rabbitmq_delayed_message_exchange plugin depends on Mnesia which was removed.
+    /// rabbitmq_delayed_message_exchange plugin depends on Mnesia which was removed. When the server
+    /// version could not be determined, the probe is still attempted so the plugin is used if available.
     /// </summary>
     /// <returns>true if the delayed exchange was successfully declared, meaning the plugin is installed.</returns>
     private async Task<bool> CreateDelayedExchangeAsync(IChannel channel)

--- a/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqServerVersionTests.cs
+++ b/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqServerVersionTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Foundatio.Messaging;
+using Xunit;
+
+namespace Foundatio.RabbitMQ.Tests.Messaging;
+
+public class RabbitMqServerVersionTests
+{
+    [Theory]
+    [InlineData("3.13.7", 3, 13)]
+    [InlineData("4.0.5", 4, 0)]
+    [InlineData("4.2.0", 4, 2)]
+    [InlineData("4.3.0", 4, 3)]
+    [InlineData("4.3.1", 4, 3)]
+    [InlineData("5.0.0", 5, 0)]
+    public void ParseServerVersion_WithValidVersionBytes_ReturnsVersion(string versionString, int major, int minor)
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["version"] = Encoding.UTF8.GetBytes(versionString)
+        };
+
+        var result = RabbitMQMessageBus.ParseServerVersion(properties);
+
+        Assert.NotNull(result);
+        Assert.Equal(major, result.Major);
+        Assert.Equal(minor, result.Minor);
+    }
+
+    [Fact]
+    public void ParseServerVersion_WithNullProperties_ReturnsNull()
+    {
+        var result = RabbitMQMessageBus.ParseServerVersion(null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseServerVersion_WithMissingVersionKey_ReturnsNull()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["product"] = Encoding.UTF8.GetBytes("RabbitMQ")
+        };
+
+        var result = RabbitMQMessageBus.ParseServerVersion(properties);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseServerVersion_WithNonByteArrayValue_ReturnsNull()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["version"] = "4.2.0"
+        };
+
+        var result = RabbitMQMessageBus.ParseServerVersion(properties);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ParseServerVersion_WithInvalidVersionBytes_ReturnsNull()
+    {
+        var properties = new Dictionary<string, object?>
+        {
+            ["version"] = Encoding.UTF8.GetBytes("not-a-version")
+        };
+
+        var result = RabbitMQMessageBus.ParseServerVersion(properties);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void VersionGating_Rmq42_IsBelow43()
+    {
+        var rmq42 = new Version(4, 2, 0);
+        var rmq43 = new Version(4, 3);
+        Assert.True(rmq42 < rmq43);
+    }
+
+    [Fact]
+    public void VersionGating_Rmq43_IsAtOrAbove43()
+    {
+        var rmq43 = new Version(4, 3, 0);
+        var threshold = new Version(4, 3);
+        Assert.True(rmq43 >= threshold);
+    }
+
+    [Fact]
+    public void VersionGating_Rmq50_IsAbove43()
+    {
+        var rmq50 = new Version(5, 0, 0);
+        var threshold = new Version(4, 3);
+        Assert.True(rmq50 >= threshold);
+    }
+}

--- a/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqServerVersionTests.cs
+++ b/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqServerVersionTests.cs
@@ -17,13 +17,16 @@ public class RabbitMqServerVersionTests
     [InlineData("5.0.0", 5, 0)]
     public void ParseServerVersion_WithValidVersionBytes_ReturnsVersion(string versionString, int major, int minor)
     {
+        // Arrange
         var properties = new Dictionary<string, object?>
         {
             ["version"] = Encoding.UTF8.GetBytes(versionString)
         };
 
+        // Act
         var result = RabbitMQMessageBus.ParseServerVersion(properties);
 
+        // Assert
         Assert.NotNull(result);
         Assert.Equal(major, result.Major);
         Assert.Equal(minor, result.Minor);
@@ -32,67 +35,100 @@ public class RabbitMqServerVersionTests
     [Fact]
     public void ParseServerVersion_WithNullProperties_ReturnsNull()
     {
+        // Act
         var result = RabbitMQMessageBus.ParseServerVersion(null);
+
+        // Assert
         Assert.Null(result);
     }
 
     [Fact]
     public void ParseServerVersion_WithMissingVersionKey_ReturnsNull()
     {
+        // Arrange
         var properties = new Dictionary<string, object?>
         {
             ["product"] = Encoding.UTF8.GetBytes("RabbitMQ")
         };
 
+        // Act
         var result = RabbitMQMessageBus.ParseServerVersion(properties);
+
+        // Assert
         Assert.Null(result);
     }
 
     [Fact]
     public void ParseServerVersion_WithNonByteArrayValue_ReturnsNull()
     {
+        // Arrange
         var properties = new Dictionary<string, object?>
         {
             ["version"] = "4.2.0"
         };
 
+        // Act
         var result = RabbitMQMessageBus.ParseServerVersion(properties);
+
+        // Assert
         Assert.Null(result);
     }
 
     [Fact]
     public void ParseServerVersion_WithInvalidVersionBytes_ReturnsNull()
     {
+        // Arrange
         var properties = new Dictionary<string, object?>
         {
             ["version"] = Encoding.UTF8.GetBytes("not-a-version")
         };
 
+        // Act
         var result = RabbitMQMessageBus.ParseServerVersion(properties);
+
+        // Assert
         Assert.Null(result);
     }
 
     [Fact]
     public void VersionGating_Rmq42_IsBelow43()
     {
+        // Arrange
         var rmq42 = new Version(4, 2, 0);
         var rmq43 = new Version(4, 3);
-        Assert.True(rmq42 < rmq43);
+
+        // Act
+        bool isBelow = rmq42 < rmq43;
+
+        // Assert
+        Assert.True(isBelow);
     }
 
     [Fact]
     public void VersionGating_Rmq43_IsAtOrAbove43()
     {
+        // Arrange
         var rmq43 = new Version(4, 3, 0);
         var threshold = new Version(4, 3);
-        Assert.True(rmq43 >= threshold);
+
+        // Act
+        bool isAtOrAbove = rmq43 >= threshold;
+
+        // Assert
+        Assert.True(isAtOrAbove);
     }
 
     [Fact]
     public void VersionGating_Rmq50_IsAbove43()
     {
+        // Arrange
         var rmq50 = new Version(5, 0, 0);
         var threshold = new Version(4, 3);
-        Assert.True(rmq50 >= threshold);
+
+        // Act
+        bool isAbove = rmq50 >= threshold;
+
+        // Assert
+        Assert.True(isAbove);
     }
 }


### PR DESCRIPTION
## Summary

- Detect RabbitMQ server version via `IConnection.ServerProperties` on first connection
- Skip the delayed exchange plugin probe entirely on RabbitMQ >= 4.3 (Mnesia removed, plugin incompatible)
- Log a deprecation warning when the plugin is successfully detected on RabbitMQ < 4.3
- Fall back to the existing in-memory delay mechanism (`MessageBusBase.SendDelayedMessage`) automatically
- Add `ParseServerVersion` public static method with comprehensive unit tests
- Document delayed message delivery behavior, plugin deprecation, and migration guidance in README

## Context

The [rabbitmq_delayed_message_exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/) plugin is archived and no longer maintained. It depends on Mnesia, which is removed in RabbitMQ 4.3. This PR ensures users are warned on older versions and the library gracefully handles the transition without breaking changes.

## Test plan

- [ ] Verify `ParseServerVersion` unit tests pass (13 tests covering valid versions, null/missing/invalid inputs, and version comparison)
- [ ] Integration test against RabbitMQ < 4.3 with plugin: delayed exchange is used, deprecation warning logged
- [ ] Integration test against RabbitMQ < 4.3 without plugin: falls back to in-memory delay
- [ ] Integration test against RabbitMQ >= 4.3: plugin probe skipped, info message logged, in-memory fallback used
