### PR TITLE
fix: adapt RabbitMQ MessageBus to two-phase dispose lifecycle

### DIFF
--- a/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
+++ b/src/Foundatio.RabbitMQ/Foundatio.RabbitMQ.csproj
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -85,6 +85,11 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
     {
     }
 
+    protected override async Task RemoveTopicSubscriptionAsync()
+    {
+        await CloseSubscriberConnectionAsync().AnyContext();
+    }
+
     protected override async Task CleanupAsync()
     {
         _factory.AutomaticRecoveryEnabled = false;

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -14,7 +14,7 @@ using RabbitMQ.Client.Exceptions;
 
 namespace Foundatio.Messaging;
 
-public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAsyncDisposable
+public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
 {
     private const string XDeliveryCountHeader = "x-delivery-count";
     private const string XOriginalMessageIdHeader = "x-original-message-id";
@@ -31,7 +31,6 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     private bool? _delayedExchangePluginEnabled;
     private Version? _serverVersion;
     private readonly bool _isQuorumQueue;
-    private bool _isDisposed;
     private volatile bool _isPublisherBlocked;
     private volatile string? _publisherBlockedReason;
 
@@ -86,10 +85,12 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
     {
     }
 
-    protected override Task RemoveTopicSubscriptionAsync()
+    protected override async Task CleanupAsync()
     {
-        _logger.LogTrace("RemoveTopicSubscriptionAsync");
-        return CloseSubscriberConnectionAsync(DisposedCancellationToken);
+        _factory.AutomaticRecoveryEnabled = false;
+
+        await ClosePublisherConnectionAsync().AnyContext();
+        await CloseSubscriberConnectionAsync().AnyContext();
     }
 
     protected override async Task EnsureTopicSubscriptionAsync(CancellationToken cancellationToken)
@@ -231,6 +232,11 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
 
             if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
                 await subscriberChannel.BasicAckAsync(envelope.DeliveryTag, false).AnyContext();
+        }
+        catch (OperationCanceledException)
+        {
+            if (_options.AcknowledgementStrategy == AcknowledgementStrategy.Automatic)
+                await subscriberChannel.BasicRejectAsync(envelope.DeliveryTag, true).AnyContext();
         }
         catch (MessageBusException)
         {
@@ -738,38 +744,6 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>, IAs
         await channel.QueueBindAsync(queueName, _options.Topic, "").AnyContext();
 
         return queueName;
-    }
-
-    public override void Dispose()
-    {
-        base.Dispose();
-
-        if (_isDisposed)
-            return;
-
-        _isDisposed = true;
-
-        _factory.AutomaticRecoveryEnabled = false;
-
-        ClosePublisherConnection();
-        CloseSubscriberConnection();
-        GC.SuppressFinalize(this);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        base.Dispose();
-
-        if (_isDisposed)
-            return;
-
-        _isDisposed = true;
-
-        _factory.AutomaticRecoveryEnabled = false;
-
-        await ClosePublisherConnectionAsync().AnyContext();
-        await CloseSubscriberConnectionAsync().AnyContext();
-        GC.SuppressFinalize(this);
     }
 
     private void ClosePublisherConnection(CancellationToken cancellationToken = default)

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -746,30 +746,6 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
         return queueName;
     }
 
-    private void ClosePublisherConnection(CancellationToken cancellationToken = default)
-    {
-        if (_publisherConnection is null)
-            return;
-
-        using (_lock.Lock(cancellationToken))
-        {
-            _logger.LogTrace("ClosePublisherConnection");
-
-            if (_publisherChannel is not null)
-            {
-                _publisherChannel.Dispose();
-                _publisherChannel = null;
-            }
-
-            if (_publisherConnection is not null)
-            {
-                UnregisterPublisherConnectionEventHandlers();
-                _publisherConnection.Dispose();
-                _publisherConnection = null;
-            }
-        }
-    }
-
     private async Task ClosePublisherConnectionAsync()
     {
         if (_publisherConnection is null)
@@ -790,36 +766,6 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
                 UnregisterPublisherConnectionEventHandlers();
                 await _publisherConnection.DisposeAsync().AnyContext();
                 _publisherConnection = null;
-            }
-        }
-    }
-
-    private void CloseSubscriberConnection(CancellationToken cancellationToken = default)
-    {
-        if (_subscriberConnection is null)
-            return;
-
-        using (_lock.Lock(cancellationToken))
-        {
-            _logger.LogTrace("CloseSubscriberConnection");
-
-            if (_consumer is not null)
-            {
-                UnregisterConsumerEventHandlers();
-                _consumer = null;
-            }
-
-            if (_subscriberChannel is not null)
-            {
-                _subscriberChannel.Dispose();
-                _subscriberChannel = null;
-            }
-
-            if (_subscriberConnection is not null)
-            {
-                UnregisterSubscriberConnectionEventHandlers();
-                _subscriberConnection.Dispose();
-                _subscriberConnection = null;
             }
         }
     }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
+++ b/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
@@ -67,24 +67,6 @@ public abstract class RabbitMqMessageBusTestBase(string connectionString, ITestO
     }
 
     [Fact]
-    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
-    {
-        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
-    }
-
-    [Fact]
     public override Task CanSubscribeConcurrentlyAsync()
     {
         return base.CanSubscribeConcurrentlyAsync();
@@ -157,6 +139,13 @@ public abstract class RabbitMqMessageBusTestBase(string connectionString, ITestO
     }
 
     [Fact]
+    public override Task CanHandlePoisonedMessageAsync()
+    {
+        // Fire and Forget is the default
+        return base.CanHandlePoisonedMessageAsync();
+    }
+
+    [Fact]
     public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
@@ -181,6 +170,24 @@ public abstract class RabbitMqMessageBusTestBase(string connectionString, ITestO
     }
 
     [Fact]
+    public override Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
+    {
+        return base.PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
+    {
+        return base.PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
+    {
+        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+    }
+
+    [Fact]
     public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
         return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
@@ -193,28 +200,21 @@ public abstract class RabbitMqMessageBusTestBase(string connectionString, ITestO
     }
 
     [Fact]
-    public override Task CanHandlePoisonedMessageAsync()
+    public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
-        // Fire and Forget is the default
-        return base.CanHandlePoisonedMessageAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
-    {
-        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
-    {
-        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+        return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
     }
 
     [Fact]
     public override Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
     {
         return base.SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
+    {
+        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
     }
 
     [Fact]

--- a/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
+++ b/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
@@ -151,9 +151,9 @@ public abstract class RabbitMqMessageBusTestBase(string connectionString, ITestO
     }
 
     [Fact]
-    public override void CanDisposeWithNoSubscribersOrPublishers()
+    public override Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        base.CanDisposeWithNoSubscribersOrPublishers();
+        return base.CanDisposeWithNoSubscribersOrPublishersAsync();
     }
 
     [Fact]

--- a/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
+++ b/tests/Foundatio.RabbitMQ.Tests/Messaging/RabbitMqMessageBusTestBase.cs
@@ -157,6 +157,42 @@ public abstract class RabbitMqMessageBusTestBase(string connectionString, ITestO
     }
 
     [Fact]
+    public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
+    {
+        return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+    }
+
+    [Fact]
     public override Task CanHandlePoisonedMessageAsync()
     {
         // Fire and Forget is the default


### PR DESCRIPTION
## Summary
- Remove ad-hoc Dispose/DisposeAsync overrides in favor of base class two-phase dispose
- Add \CleanupAsync\ override for connection/channel teardown and disabling auto-recovery
- Handle \OperationCanceledException\ in \OnMessageAsync\ to requeue messages during shutdown

## Dependencies
- Depends on FoundatioFx/Foundatio#492 (core two-phase dispose)

## Test plan
- [x] Builds with local Foundatio source (\ReferenceFoundatioSource=true\)
- [ ] CI runs integration tests with RabbitMQ