### PR TITLE
Deprecate GlobalQos and delayed exchange plugin for RabbitMQ 4.3+

### DIFF
--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -144,9 +144,22 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
             // Set QoS (Quality of Service) settings for the consumer
             if (_options.PrefetchCount > 0 || _options.PrefetchSize > 0)
             {
-                await _subscriberChannel.BasicQosAsync(_options.PrefetchSize, _options.PrefetchCount, _options.GlobalQos, cancellationToken).AnyContext();
+#pragma warning disable CS0618 // GlobalQos is obsolete but we still need to read it for backward compatibility
+                bool useGlobalQos = _options.GlobalQos;
+#pragma warning restore CS0618
+                if (useGlobalQos && _serverVersion is not null && _serverVersion >= _delayedExchangePluginIncompatibleVersion)
+                {
+                    _logger.LogWarning("GlobalQos is not supported on RabbitMQ {ServerVersion}. Falling back to per-channel prefetch (global: false). Remove the GlobalQos option to suppress this warning", _serverVersion);
+                    useGlobalQos = false;
+                }
+                else if (useGlobalQos)
+                {
+                    _logger.LogWarning("GlobalQos is deprecated in RabbitMQ 4.3+ and will be removed in a future version. Use per-channel prefetch instead");
+                }
+
+                await _subscriberChannel.BasicQosAsync(_options.PrefetchSize, _options.PrefetchCount, useGlobalQos, cancellationToken).AnyContext();
                 _logger.LogDebug("Set channel QoS - PrefetchCount: {PrefetchCount}, PrefetchSize: {PrefetchSize}, Global: {GlobalQos} for acknowledgment strategy {AcknowledgementStrategy}",
-                    _options.PrefetchCount, _options.PrefetchSize, _options.GlobalQos, _options.AcknowledgementStrategy);
+                    _options.PrefetchCount, _options.PrefetchSize, useGlobalQos, _options.AcknowledgementStrategy);
             }
             else
             {
@@ -591,7 +604,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
         // if the RabbitMQ plugin is not available, then use the base class delay mechanism
         if (_delayedExchangePluginEnabled is false && options.DeliveryDelay.HasValue && options.DeliveryDelay.Value > TimeSpan.Zero)
         {
-            _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
+            _logger.LogDebug("Delayed message will be scheduled in-memory (broker-side delayed exchange unavailable): {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
             var mappedType = GetMappedMessageType(messageType);
             if (mappedType is null)
                 throw new MessageBusException($"Unable to resolve CLR type for delayed message: {messageType}");
@@ -703,8 +716,8 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
 
         if (_serverVersion is not null && _serverVersion >= _delayedExchangePluginIncompatibleVersion)
         {
-            _logger.LogInformation(
-                "Skipping delayed exchange plugin probe: RabbitMQ {ServerVersion} removed Mnesia, plugin is incompatible",
+            _logger.LogWarning(
+                "The rabbitmq_delayed_message_exchange plugin is incompatible with RabbitMQ {ServerVersion} (Mnesia removed). Delayed messages will be scheduled in-memory. Support for this plugin will be removed in a future version",
                 _serverVersion);
             _delayedExchangePluginEnabled = false;
             return null;
@@ -734,7 +747,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
         if (success)
         {
             _logger.LogWarning(
-                "The rabbitmq_delayed_message_exchange plugin is deprecated and incompatible with RabbitMQ 4.3+. See https://github.com/rabbitmq/rabbitmq-delayed-message-exchange for details. Plan migration before upgrading to RabbitMQ 4.3");
+                "The rabbitmq_delayed_message_exchange plugin is deprecated and incompatible with RabbitMQ 4.3+. Support will be removed in a future version and delayed messages will fall back to in-memory scheduling. See https://github.com/rabbitmq/rabbitmq-delayed-message-exchange for details");
         }
 
         _delayedExchangePluginEnabled = success;

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBus.cs
@@ -19,6 +19,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
     private const string XDeliveryCountHeader = "x-delivery-count";
     private const string XOriginalMessageIdHeader = "x-original-message-id";
     private static readonly Version _delayedExchangePluginIncompatibleVersion = new(4, 3);
+    private static readonly Version _globalQosRemovedVersion = new(4, 3);
 
     private readonly AsyncLock _lock = new();
     private readonly AsyncManualResetEvent _publisherReady = new(true);
@@ -147,12 +148,12 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
 #pragma warning disable CS0618 // GlobalQos is obsolete but we still need to read it for backward compatibility
                 bool useGlobalQos = _options.GlobalQos;
 #pragma warning restore CS0618
-                if (useGlobalQos && _serverVersion is not null && _serverVersion >= _delayedExchangePluginIncompatibleVersion)
+                if (useGlobalQos && _serverVersion is not null && _serverVersion >= _globalQosRemovedVersion)
                 {
                     _logger.LogWarning("GlobalQos is not supported on RabbitMQ {ServerVersion}. Falling back to per-channel prefetch (global: false). Remove the GlobalQos option to suppress this warning", _serverVersion);
                     useGlobalQos = false;
                 }
-                else if (useGlobalQos)
+                else if (useGlobalQos && _serverVersion is not null)
                 {
                     _logger.LogWarning("GlobalQos is deprecated in RabbitMQ 4.3+ and will be removed in a future version. Use per-channel prefetch instead");
                 }
@@ -604,7 +605,7 @@ public class RabbitMQMessageBus : MessageBusBase<RabbitMQMessageBusOptions>
         // if the RabbitMQ plugin is not available, then use the base class delay mechanism
         if (_delayedExchangePluginEnabled is false && options.DeliveryDelay.HasValue && options.DeliveryDelay.Value > TimeSpan.Zero)
         {
-            _logger.LogDebug("Delayed message will be scheduled in-memory (broker-side delayed exchange unavailable): {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
+            _logger.LogTrace("Delayed message will be scheduled in-memory (broker-side delayed exchange unavailable): {MessageType} ({Delay}ms)", messageType, options.DeliveryDelay.Value.TotalMilliseconds);
             var mappedType = GetMappedMessageType(messageType);
             if (mappedType is null)
                 throw new MessageBusException($"Unable to resolve CLR type for delayed message: {messageType}");

--- a/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBusOptions.cs
+++ b/src/Foundatio.RabbitMQ/Messaging/RabbitMQMessageBusOptions.cs
@@ -71,6 +71,7 @@ public class RabbitMQMessageBusOptions : SharedMessageBusOptions
     /// When true, the QoS settings apply to all consumers on the connection.
     /// When false (default), the QoS settings apply only to consumers on this channel.
     /// </summary>
+    [Obsolete("Global QoS is deprecated in RabbitMQ 4.3+ and will be removed in a future version. Use per-channel prefetch (GlobalQos = false) instead.")]
     public bool GlobalQos { get; set; }
 
     /// <summary>
@@ -184,9 +185,12 @@ public class RabbitMQMessageBusOptionsBuilder : SharedMessageBusOptionsBuilder<R
         return this;
     }
 
+    [Obsolete("Global QoS is deprecated in RabbitMQ 4.3+ and will be removed in a future version. Use per-channel prefetch (GlobalQos = false) instead.")]
     public RabbitMQMessageBusOptionsBuilder GlobalQos(bool globalQos)
     {
+#pragma warning disable CS0618
         Target.GlobalQos = globalQos;
+#pragma warning restore CS0618
         return this;
     }
 


### PR DESCRIPTION
## Summary

- Mark `GlobalQos` property and builder method as `[Obsolete]` since RabbitMQ 4.3+ moved `global_qos` to `denied_by_default`
- Guard `BasicQosAsync`: when connected to RabbitMQ 4.3+, downgrade to per-channel prefetch (`global: false`) with a warning instead of sending `global: true` which would kill the channel
- Upgrade delayed exchange plugin warnings to clearly state that delayed messages fall back to in-memory scheduling and that plugin support will be removed in a future version

## Context

RabbitMQ [4.3.0](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0) (released April 2026) removed Mnesia entirely and moved several deprecated features to `denied_by_default`. The latest patch is [4.3.1](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.1).

Affected features:
- `global_qos` - server rejects `BasicQos(global: true)` unless explicitly re-enabled via `deprecated_features.permit.global_qos = true` in `rabbitmq.conf`
- `rabbitmq_delayed_message_exchange` plugin - depends on Mnesia, incompatible with 4.3+

This library already detected 4.3+ and skipped the delayed exchange probe, but the `GlobalQos` option had no guard and would cause channel death on 4.3+ servers. Neither feature was marked deprecated in the public API.

## Test plan

- [x] `dotnet build` passes with 0 warnings, 0 errors
- [ ] Verify `[Obsolete]` compiler warning appears when consumer code uses `GlobalQos`
- [ ] Verify on RabbitMQ 4.3+ server: no channel errors when `GlobalQos = true` is configured (graceful downgrade with warning)
- [ ] Verify delayed message in-memory fallback still works correctly
